### PR TITLE
Initial work to support Mixer chat via standard UE chat interface. 

### DIFF
--- a/Source/MixerInteractivity/MixerInteractivity.build.cs
+++ b/Source/MixerInteractivity/MixerInteractivity.build.cs
@@ -18,10 +18,12 @@ public class MixerInteractivity : ModuleRules
 				"SlateCore",
 				"Slate",
 				"UMG",
+				"WebSockets",
 			});
 
 		// Need Version.h
 		PrivateIncludePathModuleNames.Add("Launch");
+		PrivateIncludePathModuleNames.Add("OnlineSubsystem");
 
 		string ThirdPartyFolder = Path.Combine(ModuleDirectory, "..", "..", "ThirdParty");
 		PrivateIncludePaths.Add(Path.Combine(ThirdPartyFolder, "Include"));

--- a/Source/MixerInteractivity/Private/MixerChatConnection.cpp
+++ b/Source/MixerInteractivity/Private/MixerChatConnection.cpp
@@ -1,3 +1,12 @@
+//*********************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+// THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
+// ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY
+// IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR
+// PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
+//
+//*********************************************************
 #include "MixerChatConnection.h"
 
 #include "MixerInteractivityModule.h"

--- a/Source/MixerInteractivity/Private/MixerChatConnection.cpp
+++ b/Source/MixerInteractivity/Private/MixerChatConnection.cpp
@@ -45,6 +45,7 @@ namespace MixerChatStringConstants
 		const FString UserLeave = TEXT("UserLeave");
 		const FString DeleteMessage = TEXT("DeleteMessage");
 		const FString ClearMessages = TEXT("ClearMessages");
+		const FString PurgeMessage = TEXT("PurgeMessage");
 	}
 
 	namespace FieldNames
@@ -806,6 +807,7 @@ void FMixerChatConnection::DeleteFromChatHistoryIf(TFunctionRef<bool(TSharedPtr<
 	TSharedPtr<FChatMessageMixerImpl> ChatMessage = ChatHistoryNewest;
 	while (ChatMessage.IsValid())
 	{
+		TSharedPtr<FChatMessageMixerImpl> NextMessage = ChatMessage->NextLink;
 		if (Predicate(ChatMessage))
 		{
 			ChatMessage->FlagAsDeleted();
@@ -828,9 +830,8 @@ void FMixerChatConnection::DeleteFromChatHistoryIf(TFunctionRef<bool(TSharedPtr<
 			ChatMessage->NextLink.Reset();
 			ChatMessage->PrevLink.Reset();
 			--ChatHistoryNum;
-			break;
 		}
-		ChatMessage = ChatMessage->NextLink;
+		ChatMessage = NextMessage;
 	}
 }
 
@@ -948,6 +949,7 @@ FMixerChatConnection::FServerMessageHandler FMixerChatConnection::GetEventHandle
 		EventHandlers.Add(MixerChatStringConstants::EventTypes::UserLeave, &FMixerChatConnection::HandleUserLeaveEvent);
 		EventHandlers.Add(MixerChatStringConstants::EventTypes::DeleteMessage, &FMixerChatConnection::HandleDeleteMessageEvent);
 		EventHandlers.Add(MixerChatStringConstants::EventTypes::ClearMessages, &FMixerChatConnection::HandleClearMessagesEvent);
+		EventHandlers.Add(MixerChatStringConstants::EventTypes::PurgeMessage, &FMixerChatConnection::HandlePurgeMessageEvent);
 	}
 
 	FServerMessageHandler* Handler = EventHandlers.Find(EventType);

--- a/Source/MixerInteractivity/Private/MixerChatConnection.cpp
+++ b/Source/MixerInteractivity/Private/MixerChatConnection.cpp
@@ -627,7 +627,7 @@ void FMixerChatConnection::SendMethodPacket(const FString& Payload, FServerMessa
 	WebSocket->Send(Payload);
 }
 
-void FMixerChatConnection::GetMessageHistory(int32 NumMessages, TArray< TSharedRef<FChatMessage> >& OutMessages)
+void FMixerChatConnection::GetMessageHistory(int32 NumMessages, TArray< TSharedRef<FChatMessage> >& OutMessages) const
 {
 	TSharedPtr<FChatMessageMixerImpl> ChatMessage = ChatHistoryNewest;
 	while (ChatMessage.IsValid() &&
@@ -870,4 +870,17 @@ FMixerChatConnection::FServerMessageHandler FMixerChatConnection::GetEventHandle
 	return Handler != nullptr ? *Handler : nullptr;
 }
 
+void FMixerChatConnection::GetAllCachedUsers(TArray< TSharedRef<FChatRoomMember> >& OutUsers) const
+{
+	for (TMap<FUniqueNetIdMixer, TSharedPtr<FMixerChatUser>>::TConstIterator It(CachedUsers); It; ++It)
+	{
+		OutUsers.Add(It->Value.ToSharedRef());
+	}
+}
+
+TSharedPtr<FMixerChatUser> FMixerChatConnection::FindUser(const FUniqueNetId& UserId) const
+{
+	const TSharedPtr<FMixerChatUser>* User = CachedUsers.Find(FUniqueNetIdMixer(UserId));
+	return User != nullptr ? *User : nullptr;
+}
 

--- a/Source/MixerInteractivity/Private/MixerChatConnection.cpp
+++ b/Source/MixerInteractivity/Private/MixerChatConnection.cpp
@@ -1,0 +1,455 @@
+#include "MixerChatConnection.h"
+
+#include "MixerInteractivityModule.h"
+#include "MixerInteractivityTypes.h"
+#include "MixerInteractivityUserSettings.h"
+#include "OnlineChatMixer.h"
+
+#include "HttpModule.h"
+#include "PlatformHttp.h"
+#include "JsonTypes.h"
+#include "JsonPrintPolicy.h"
+#include "Dom/JsonValue.h"
+#include "Dom/JsonObject.h"
+#include "Serialization/JsonReader.h"
+#include "Serialization/JsonWriter.h"
+#include "Serialization/JsonSerializer.h"
+#include "WebsocketsModule.h"
+#include "IWebSocket.h"
+#include "OnlineSubsystemTypes.h"
+
+DEFINE_LOG_CATEGORY(LogMixerChat);
+
+bool FMixerChatConnection::Init()
+{
+#if WITH_WEBSOCKETS
+	TSharedRef<IHttpRequest> ChannelRequest = FHttpModule::Get().CreateRequest();
+	ChannelRequest->SetVerb(TEXT("GET"));
+	ChannelRequest->SetURL(FString::Printf(TEXT("https://mixer.com/api/v1/channels/%s"), *RoomId));
+
+	ChannelRequest->OnProcessRequestComplete().BindSP(this, &FMixerChatConnection::OnGetChannelInfoForRoomIdComplete);
+	return ChannelRequest->ProcessRequest();
+#else
+	UE_LOG(LogMixerChat, Warning, TEXT("Mixer chat requires websockets which are not available on this platform."));
+	return false;
+#endif
+}
+
+void FMixerChatConnection::Cleanup()
+{
+	CloseWebSocket();
+}
+
+void FMixerChatConnection::JoinDiscoveredChatChannel()
+{
+	TSharedRef<IHttpRequest> ChatRequest = FHttpModule::Get().CreateRequest();
+	ChatRequest->SetVerb(TEXT("GET"));
+	ChatRequest->SetURL(FString::Printf(TEXT("https://mixer.com/api/v1/chats/%d?fields=id"), ChannelId));
+
+#if PLATFORM_SUPPORTS_MIXER_OAUTH
+	const UMixerInteractivityUserSettings* UserSettings = GetDefault<UMixerInteractivityUserSettings>();
+	if (UserSettings->AccessToken.Len() > 0)
+	{
+		FString AuthZHeaderValue = FString::Printf(TEXT("Bearer %s"), *UserSettings->AccessToken);
+		ChatRequest->SetHeader(TEXT("Authorization"), AuthZHeaderValue);
+	}
+	else
+	{
+		UE_LOG(LogMixerChat, Warning, TEXT("No OAuth token found.  Chat connection will be anonymous and will not allow sending messages.  Sign in to Mixer to enable."));
+	}
+#else
+	UE_LOG(LogMixerChat, Warning, TEXT("Chat authentication is not yet supported on this platform.  Chat connection will be anonymous and will not allow sending messages."));
+#endif
+
+	ChatRequest->OnProcessRequestComplete().BindSP(this, &FMixerChatConnection::OnDiscoverChatServersComplete);
+	if (!ChatRequest->ProcessRequest())
+	{
+		FString ErrorMessage = TEXT("Failed to send request for chat web socket connection info.");
+		UE_LOG(LogMixerChat, Warning, TEXT("%s for room %s"), *ErrorMessage, *RoomId);
+		IMixerInteractivityModule::Get().GetChatInterface()->TriggerOnChatRoomJoinPublicDelegates(*User, RoomId, false, ErrorMessage);
+	}
+}
+
+void FMixerChatConnection::OnGetChannelInfoForRoomIdComplete(FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bSucceeded)
+{
+	if (bSucceeded && HttpResponse.IsValid())
+	{
+		if (EHttpResponseCodes::IsOk(HttpResponse->GetResponseCode()))
+		{
+			FString ResponseStr = HttpResponse->GetContentAsString();
+			TSharedRef<TJsonReader<>> JsonReader = TJsonReaderFactory<>::Create(ResponseStr);
+			TSharedPtr<FJsonObject> JsonObject;
+			if (FJsonSerializer::Deserialize(JsonReader, JsonObject) &&
+				JsonObject.IsValid())
+			{
+				JsonObject->TryGetNumberField(TEXT("id"), ChannelId);
+			}
+		}
+	}
+
+	if (ChannelId != 0)
+	{
+		JoinDiscoveredChatChannel();
+	}
+	else
+	{
+		OnChatConnectionError(TEXT("Could not find Mixer chat channel for room id."));
+	}
+}
+
+void FMixerChatConnection::OnDiscoverChatServersComplete(FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bSucceeded)
+{
+	if (bSucceeded && HttpResponse.IsValid())
+	{
+		if (EHttpResponseCodes::IsOk(HttpResponse->GetResponseCode()))
+		{
+			FString ResponseStr = HttpResponse->GetContentAsString();
+			TSharedRef<TJsonReader<>> JsonReader = TJsonReaderFactory<>::Create(ResponseStr);
+			TSharedPtr<FJsonObject> JsonObject;
+			if (FJsonSerializer::Deserialize(JsonReader, JsonObject) &&
+				JsonObject.IsValid())
+			{
+				const TArray<TSharedPtr<FJsonValue>> *JsonEndpoints;
+				if (JsonObject->TryGetArrayField(TEXT("endpoints"), JsonEndpoints))
+				{
+					for (const TSharedPtr<FJsonValue>& Endpoint : *JsonEndpoints)
+					{
+						Endpoints.Add(Endpoint->AsString());
+					}
+
+					JsonObject->TryGetStringField(TEXT("authkey"), AuthKey);
+					OpenWebSocket();
+				}
+			}
+		}
+	}
+
+	// Should have a web socket going by now.
+	if (!WebSocket.IsValid())
+	{
+		OnChatConnectionError(TEXT("Failed to create web socket"));
+	}
+}
+
+void FMixerChatConnection::OnChatSocketConnected()
+{
+	FString AuthPacketString;
+	TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&AuthPacketString);
+	Writer->WriteObjectStart();
+	Writer->WriteValue(TEXT("type"), TEXT("method"));
+	Writer->WriteValue(TEXT("method"), TEXT("auth"));
+	Writer->WriteArrayStart(TEXT("arguments"));
+	Writer->WriteValue(ChannelId);
+	TSharedPtr<const FMixerLocalUser> CurrentUser = IMixerInteractivityModule::Get().GetCurrentUser();
+	if (CurrentUser.IsValid() && !AuthKey.IsEmpty())
+	{
+		UE_LOG(LogMixerChat, Log, TEXT("Authenticating to chat room %s as user '%s'"), *RoomId, *CurrentUser->Name);
+		Writer->WriteValue(CurrentUser->Id);
+		Writer->WriteValue(AuthKey);
+	}
+	else
+	{
+		UE_LOG(LogMixerChat, Log, TEXT("Authenticating to chat room %s anonymously"), *RoomId);
+	}
+	Writer->WriteArrayEnd();
+	Writer->WriteValue(TEXT("id"), MessageId++);
+	Writer->WriteObjectEnd();
+	Writer->Close();
+
+	WebSocket->Send(AuthPacketString);
+}
+
+void FMixerChatConnection::OnChatConnectionError(const FString& ErrorMessage)
+{
+	UE_LOG(LogMixerChat, Warning, TEXT("Failed to connect chat web socket for room %s with error '%s'"), *RoomId, *ErrorMessage);
+	IMixerInteractivityModule::Get().GetChatInterface()->TriggerOnChatRoomJoinPublicDelegates(*User, RoomId, false, ErrorMessage);
+}
+
+void FMixerChatConnection::OnChatSocketClosed(int32 StatusCode, const FString& Reason, bool bWasClean)
+{
+	// This should be a remote close since we unhook event handlers before closing on our end.
+	// Do a full close and re-open of the websocket so as to (potentially) hit a different endpoint, per Mixer guidance.
+
+	UE_LOG(LogMixerChat, Warning, TEXT("Chat websocket closed with reason '%s'.  Attempting to reconnect."), *Reason);
+
+	CloseWebSocket();
+
+	OpenWebSocket();
+}
+
+void FMixerChatConnection::OnChatPacket(const FString& PacketJsonString)
+{
+	TSharedRef<TJsonReader<>> JsonReader = TJsonReaderFactory<>::Create(PacketJsonString);
+	TSharedPtr<FJsonObject> JsonObject;
+	if (FJsonSerializer::Deserialize(JsonReader, JsonObject) &&
+		JsonObject.IsValid())
+	{
+		FString MessageType;
+		if (JsonObject->TryGetStringField(TEXT("type"), MessageType))
+		{
+			if (MessageType == TEXT("reply"))
+			{
+				// @TODO - Response to a method we called.  Verify success, handle results, etc.
+			}
+			else if (MessageType == TEXT("event"))
+			{
+				FString EventType;
+				if (JsonObject->TryGetStringField(TEXT("event"), EventType))
+				{
+					if (EventType == TEXT("WelcomeEvent"))
+					{
+						// Welcomed by the server.  We are now fully connected.
+						bIsReady = true;
+						IMixerInteractivityModule::Get().GetChatInterface()->TriggerOnChatRoomJoinPublicDelegates(*User, RoomId, true, TEXT(""));
+					}
+					else
+					{
+						// Data field is important for all the following event types
+						const TSharedPtr<FJsonObject>* Data;
+						if (!JsonObject->TryGetObjectField(TEXT("data"), Data))
+						{
+							UE_LOG(LogMixerChat, Error, TEXT("Missing data field for chat event of type %s (full payload %s)"), *EventType, *PacketJsonString);
+							return;
+						}
+
+						check(Data != nullptr);
+						check(Data->IsValid());
+
+						if (EventType == TEXT("ChatMessage"))
+						{
+							HandleChatMessagePacket(Data->Get());
+						}
+						else if (EventType == TEXT("UserJoin"))
+						{
+							FString JoiningUser;
+							if ((*Data)->TryGetStringField(TEXT("username"), JoiningUser))
+							{
+								UE_LOG(LogMixerChat, Log, TEXT("%s is joining %s's chat channel"), *JoiningUser, *RoomId);
+
+								// @TODO: we should probably create a derived FUniqueNetId for Mixer.
+								TSharedRef<FUniqueNetId> JoiningId = MakeShared<FUniqueNetIdString>(JoiningUser);
+								IMixerInteractivityModule::Get().GetChatInterface()->TriggerOnChatRoomMemberJoinDelegates(*User, RoomId, *JoiningId);
+							}
+						}
+						else if (EventType == TEXT("UserLeave"))
+						{
+							FString LeavingUser;
+							if ((*Data)->TryGetStringField(TEXT("username"), LeavingUser))
+							{
+								UE_LOG(LogMixerChat, Log, TEXT("%s is leaving %s's chat channel"), *LeavingUser, *RoomId);
+
+								// @TODO: we should probably create a derived FUniqueNetId for Mixer.
+								TSharedRef<FUniqueNetId> LaavingId = MakeShared<FUniqueNetIdString>(LeavingUser);
+								IMixerInteractivityModule::Get().GetChatInterface()->TriggerOnChatRoomMemberExitDelegates(*User, RoomId, *LaavingId);
+							}
+						}
+					}
+				}
+				else
+				{
+					UE_LOG(LogMixerChat, Error, TEXT("Missing event (type) field for chat event (full payload %s)"), *PacketJsonString);
+				}
+			}
+			else
+			{
+				// Unknown message type
+				UE_LOG(LogMixerChat, Error, TEXT("Unknown message of type %s on chat socket (full payload %s)"), *MessageType, *PacketJsonString);
+			}
+		}
+		else
+		{
+			UE_LOG(LogMixerChat, Error, TEXT("Missing type field for chat socket message (full payload %s)"), *PacketJsonString);
+		}
+	}
+}
+
+void FMixerChatConnection::HandleChatMessagePacket(FJsonObject* Payload)
+{
+	FString FromUser;
+	if (!Payload->TryGetStringField(TEXT("user_name"), FromUser))
+	{
+		UE_LOG(LogMixerChat, Error, TEXT("Missing user_name field for chat event"));
+		return;
+	}
+
+	const TSharedPtr<FJsonObject>* MessageObject;
+	if (!Payload->TryGetObjectField(TEXT("message"), MessageObject))
+	{
+		UE_LOG(LogMixerChat, Error, TEXT("Missing message field for chat event"));
+		return;
+	}
+
+	const TSharedPtr<FJsonObject>* Metadata;
+	bool bIsWhisper = false;
+	bool bIsAction = false;
+	if ((*MessageObject)->TryGetObjectField(TEXT("meta"), Metadata))
+	{
+		(*Metadata)->TryGetBoolField(TEXT("whisper"), bIsWhisper);
+		(*Metadata)->TryGetBoolField(TEXT("me"), bIsAction);
+	}
+
+	FString MessageString;
+	if (bIsAction)
+	{
+		MessageString = FromUser + TEXT(" ");
+	}
+
+	const TArray<TSharedPtr<FJsonValue>>* MessageFragmentArray;
+	if (!(*MessageObject)->TryGetArrayField(TEXT("message"), MessageFragmentArray))
+	{
+		UE_LOG(LogMixerChat, Error, TEXT("Missing message.message array for chat event"));
+		return;
+	}
+
+	for (const TSharedPtr<FJsonValue>& Fragment : *MessageFragmentArray)
+	{
+		const TSharedPtr<FJsonObject>* FragmentObj;
+		if (Fragment->TryGetObject(FragmentObj))
+		{
+			HandleChatMessageFragment(MessageString, FragmentObj->Get());
+		}
+	}
+
+	// @TODO: we should probably create a derived FUniqueNetId for Mixer.
+	TSharedRef<FChatMessageMixer> FinalMessage = MakeShared<FChatMessageMixer>(MakeShared<FUniqueNetIdString>(FromUser), MessageString);
+	if (bIsWhisper)
+	{
+		UE_LOG(LogMixerChat, Verbose, TEXT("Private message from %s: %s"), *FromUser, *MessageString);
+		IMixerInteractivityModule::Get().GetChatInterface()->TriggerOnChatPrivateMessageReceivedDelegates(*User, FinalMessage);
+	}
+	else
+	{
+		UE_LOG(LogMixerChat, Verbose, TEXT("Chat message from %s: %s"), *FromUser, *MessageString);
+		IMixerInteractivityModule::Get().GetChatInterface()->TriggerOnChatRoomMessageReceivedDelegates(*User, RoomId, FinalMessage);
+	}
+}
+
+void FMixerChatConnection::HandleChatMessageFragment(FString& MessageSoFar, FJsonObject* Fragment)
+{
+	FString FragmentType;
+	if (!Fragment->TryGetStringField(TEXT("type"), FragmentType))
+	{
+		UE_LOG(LogMixerChat, Error, TEXT("Missing type field for chat message fragment."));
+		return;
+	}
+
+	// For now just always append the fragment text no matter the type.
+	// In the future we could perhaps add markup?
+	FString FragmentText;
+	if (!Fragment->TryGetStringField(TEXT("text"), FragmentText))
+	{
+		UE_LOG(LogMixerChat, Error, TEXT("Missing text field for chat message fragment."));
+		return;
+	}
+
+	MessageSoFar += FragmentText;
+}
+
+bool FMixerChatConnection::SendChatMessage(const FString& MessageBody)
+{
+	if (!bIsReady)
+	{
+		UE_LOG(LogMixerChat, Warning, TEXT("Attempt to send chat to room %s before connection has been established.  Wait for OnChatRoomJoin event."), *RoomId);
+		return false;
+	}
+
+	if (IsAnonymous())
+	{
+		UE_LOG(LogMixerChat, Warning, TEXT("Attempt to send chat to room %s when connected anonymously."), *RoomId);
+		return false;
+	}
+
+	check(WebSocket.IsValid());
+	check(WebSocket->IsConnected());
+
+	FString MessagePacketString;
+	TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&MessagePacketString);
+	Writer->WriteObjectStart();
+	Writer->WriteValue(TEXT("type"), TEXT("method"));
+	Writer->WriteValue(TEXT("method"), TEXT("msg"));
+	Writer->WriteArrayStart(TEXT("arguments"));
+	Writer->WriteValue(MessageBody);
+	Writer->WriteArrayEnd();
+	Writer->WriteValue(TEXT("id"), MessageId++);
+	Writer->WriteObjectEnd();
+	Writer->Close();
+
+	WebSocket->Send(MessagePacketString);
+
+	return true;
+}
+
+bool FMixerChatConnection::SendWhisper(const FString& ToUser, const FString& MessageBody)
+{
+	if (!bIsReady)
+	{
+		UE_LOG(LogMixerChat, Warning, TEXT("Attempt to send chat to room %s before connection has been established.  Wait for OnChatRoomJoin event."), *RoomId);
+		return false;
+	}
+
+	if (IsAnonymous())
+	{
+		UE_LOG(LogMixerChat, Warning, TEXT("Attempt to send chat to room %s when connected anonymously."), *RoomId);
+		return false;
+	}
+
+	FString WhisperPacketString;
+	TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&WhisperPacketString);
+	Writer->WriteObjectStart();
+	Writer->WriteValue(TEXT("type"), TEXT("method"));
+	Writer->WriteValue(TEXT("method"), TEXT("whisper"));
+	Writer->WriteArrayStart(TEXT("arguments"));
+	Writer->WriteValue(ToUser);
+	Writer->WriteValue(MessageBody);
+	Writer->WriteArrayEnd();
+	Writer->WriteValue(TEXT("id"), MessageId++);
+	Writer->WriteObjectEnd();
+	Writer->Close();
+
+	WebSocket->Send(WhisperPacketString);
+
+	return true;
+}
+
+void FMixerChatConnection::OpenWebSocket()
+{
+	// Shouldn't ever get this far of we don't have a websocket implementation.
+	check(WITH_WEBSOCKETS != 0);
+	const FString& SelectedEndpoint = Endpoints[FMath::RandRange(0, Endpoints.Num() - 1)];
+	UE_LOG(LogMixerChat, Verbose, TEXT("Opening web socket to %s for chat room %s"), *SelectedEndpoint, *RoomId);
+
+	// Regardless, CreateWebSocket won't compile on all platforms.
+#if WITH_WEBSOCKETS
+	WebSocket = FModuleManager::LoadModuleChecked<FWebSocketsModule>("WebSockets").CreateWebSocket(SelectedEndpoint);
+#endif
+
+	if (WebSocket.IsValid())
+	{
+		WebSocket->OnConnected().AddSP(this, &FMixerChatConnection::OnChatSocketConnected);
+		WebSocket->OnConnectionError().AddSP(this, &FMixerChatConnection::OnChatConnectionError);
+		WebSocket->OnMessage().AddSP(this, &FMixerChatConnection::OnChatPacket);
+		WebSocket->OnClosed().AddSP(this, &FMixerChatConnection::OnChatSocketClosed);
+
+		WebSocket->Connect();
+	}
+}
+
+void FMixerChatConnection::CloseWebSocket()
+{
+	if (WebSocket.IsValid())
+	{
+		bIsReady = false;
+
+		WebSocket->OnConnected().RemoveAll(this);
+		WebSocket->OnConnectionError().RemoveAll(this);
+		WebSocket->OnMessage().RemoveAll(this);
+		WebSocket->OnClosed().RemoveAll(this);
+
+		if (WebSocket->IsConnected())
+		{
+			WebSocket->Close();
+		}
+
+		WebSocket.Reset();
+	}
+}

--- a/Source/MixerInteractivity/Private/MixerChatConnection.h
+++ b/Source/MixerInteractivity/Private/MixerChatConnection.h
@@ -11,19 +11,7 @@ DECLARE_LOG_CATEGORY_EXTERN(LogMixerChat, Log, All);
 class FMixerChatConnection : public TSharedFromThis<FMixerChatConnection>
 {
 public:
-	FMixerChatConnection(class FOnlineChatMixer* InChatInterface, const FUniqueNetId& UserId, const FChatRoomId& InRoomId, const FChatRoomConfig& Config)
-		: ChatInterface(InChatInterface)
-		, User(UserId.AsShared())
-		, RoomId(InRoomId)
-		, ChannelId(0)
-		, MessageId(0)
-		, ChatHistoryNum(0)
-		, ChatHistoryMax(10) // @TODO: pull from config once available
-		, bIsReady(false)
-		, bRejoinOnDisconnect(Config.bRejoinOnDisconnect)
-	{
-	}
-
+	FMixerChatConnection(class FOnlineChatMixer* InChatInterface, const FUniqueNetId& UserId, const FChatRoomId& InRoomId, const FChatRoomConfig& Config);
 	virtual ~FMixerChatConnection();
 
 	bool Init();
@@ -111,4 +99,16 @@ private:
 	int32 MessageId;
 	bool bIsReady;
 	bool bRejoinOnDisconnect;
+
+	struct
+	{
+		bool bConnect;
+		bool bChat;
+		bool bWhisper;
+		bool bPollStart;
+		bool bPollVote;
+		bool bClearMessages;
+		bool bPurge;
+		bool bGiveawayStart;
+	} Permissions;
 };

--- a/Source/MixerInteractivity/Private/MixerChatConnection.h
+++ b/Source/MixerInteractivity/Private/MixerChatConnection.h
@@ -10,12 +10,13 @@ DECLARE_LOG_CATEGORY_EXTERN(LogMixerChat, Log, All);
 class FMixerChatConnection : public TSharedFromThis<FMixerChatConnection>
 {
 public:
-	FMixerChatConnection(const FUniqueNetId& UserId, const FChatRoomId& InRoomId)
+	FMixerChatConnection(const FUniqueNetId& UserId, const FChatRoomId& InRoomId, const FChatRoomConfig& Config)
 		: User(UserId.AsShared())
 		, RoomId(InRoomId)
 		, ChannelId(0)
 		, MessageId(0)
 		, bIsReady(false)
+		, bRejoinOnDisconnect(Config.bRejoinOnDisconnect)
 	{
 	}
 
@@ -25,8 +26,10 @@ public:
 	bool SendChatMessage(const FString& MessageBody);
 	bool SendWhisper(const FString& ToUser, const FString& MessageBody);
 
-	const FChatRoomId& GetRoom() const		{ return RoomId; }
-	bool IsAnonymous() const				{ return AuthKey.IsEmpty(); }
+	const FChatRoomId& GetRoom() const			{ return RoomId; }
+	bool IsAnonymous() const					{ return AuthKey.IsEmpty(); }
+
+	void SetRejoinOnDisconnect(bool bInRejoin)	{ bRejoinOnDisconnect = bInRejoin; }
 
 private:
 
@@ -54,4 +57,5 @@ private:
 	int32 ChannelId;
 	int32 MessageId;
 	bool bIsReady;
+	bool bRejoinOnDisconnect;
 };

--- a/Source/MixerInteractivity/Private/MixerChatConnection.h
+++ b/Source/MixerInteractivity/Private/MixerChatConnection.h
@@ -36,7 +36,11 @@ public:
 
 	void SetRejoinOnDisconnect(bool bInRejoin)	{ bRejoinOnDisconnect = bInRejoin; }
 
-	void GetMessageHistory(int32 NumMessages, TArray<TSharedRef<FChatMessage>>& OutMessages);
+	void GetMessageHistory(int32 NumMessages, TArray<TSharedRef<FChatMessage>>& OutMessages) const;
+
+	void GetAllCachedUsers(TArray< TSharedRef<FChatRoomMember> >& OutUsers) const;
+
+	TSharedPtr<FMixerChatUser> FindUser(const FUniqueNetId& UserId) const;
 
 private:
 
@@ -62,20 +66,20 @@ private:
 	bool HandleDeleteMessageEvent(class FJsonObject* JsonObj);
 	bool HandleClearMessagesEvent(class FJsonObject* JsonObj);
 	bool HandlePurgeMessageEvent(class FJsonObject* JsonObj);
-	bool HandlePollStartEvent(class FJsonObject* JsonObj, TSharedPtr<struct FChatMessageMixerImpl>& OutMessage);
-	bool HandlePollEndEvent(class FJsonObject* JsonObj, TSharedPtr<struct FChatMessageMixerImpl>& OutMessage);
+	bool HandlePollStartEvent(class FJsonObject* JsonObj, TSharedPtr<FChatMessageMixerImpl>& OutMessage);
+	bool HandlePollEndEvent(class FJsonObject* JsonObj, TSharedPtr<FChatMessageMixerImpl>& OutMessage);
 
-	bool HandleChatMessageEventInternal(class FJsonObject* JsonObj, TSharedPtr<struct FChatMessageMixerImpl>& OutMessage);
-	bool HandleChatMessageEventMessageObject(class FJsonObject* JsonObj, struct FChatMessageMixerImpl* ChatMessage);
-	bool HandleChatMessageEventMessageArrayEntry(class FJsonObject* JsonObj, struct FChatMessageMixerImpl* ChatMessage);
+	bool HandleChatMessageEventInternal(class FJsonObject* JsonObj, TSharedPtr<FChatMessageMixerImpl>& OutMessage);
+	bool HandleChatMessageEventMessageObject(class FJsonObject* JsonObj, FChatMessageMixerImpl* ChatMessage);
+	bool HandleChatMessageEventMessageArrayEntry(class FJsonObject* JsonObj, FChatMessageMixerImpl* ChatMessage);
 
 	void AddMessageToChatHistory(TSharedRef<struct FChatMessageMixerImpl> ChatMessage);
-	void DeleteFromChatHistoryIf(TFunctionRef<bool(TSharedPtr<struct FChatMessageMixerImpl>)> Predicate);
+	void DeleteFromChatHistoryIf(TFunctionRef<bool(TSharedPtr<FChatMessageMixerImpl>)> Predicate);
 
 private:
 	typedef bool (FMixerChatConnection::*FServerMessageHandler)(class FJsonObject*);
 
-	void SendAuth(int32 ChannelId, const struct FMixerLocalUser* User, const FString& AuthKey);
+	void SendAuth(int32 ChannelId, const FMixerLocalUser* User, const FString& AuthKey);
 	void SendHistory(int32 MessageCount);
 
 	bool HandleAuthReply(class FJsonObject* JsonObj);
@@ -92,7 +96,7 @@ private:
 	FString AuthKey;
 	TArray<FString> Endpoints;
 	TSharedPtr<class IWebSocket> WebSocket;
-	TMap<FUniqueNetIdMixer, TSharedPtr<struct FMixerChatUser>> CachedUsers;
+	TMap<FUniqueNetIdMixer, TSharedPtr<FMixerChatUser>> CachedUsers;
 	TMap<int32, FServerMessageHandler> ReplyHandlers;
 	TSharedPtr<struct FChatMessageMixerImpl> ChatHistoryNewest;
 	TSharedPtr<struct FChatMessageMixerImpl> ChatHistoryOldest;

--- a/Source/MixerInteractivity/Private/MixerChatConnection.h
+++ b/Source/MixerInteractivity/Private/MixerChatConnection.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Interfaces/OnlineChatInterface.h"
+#include "Interfaces/IHttpRequest.h"
+#include "Interfaces/IHttpResponse.h"
+
+DECLARE_LOG_CATEGORY_EXTERN(LogMixerChat, Log, All);
+
+class FMixerChatConnection : public TSharedFromThis<FMixerChatConnection>
+{
+public:
+	FMixerChatConnection(const FUniqueNetId& UserId, const FChatRoomId& InRoomId)
+		: User(UserId.AsShared())
+		, RoomId(InRoomId)
+		, MessageId(0)
+	{
+	}
+
+	bool Init();
+	void Cleanup();
+
+	bool SendChatMessage(const FString& MessageBody);
+	bool SendWhisper(const FString& ToUser, const FString& MessageBody);
+
+	const FChatRoomId& GetRoom() const		{ return RoomId; }
+	bool IsAnonymous() const				{ return AuthKey.IsEmpty(); }
+
+private:
+
+	void OpenWebSocket();
+	void CloseWebSocket();
+
+	void JoinDiscoveredChatChannel();
+
+	void OnGetChannelInfoForRoomIdComplete(FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bSucceeded);
+	void OnDiscoverChatServersComplete(FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bSucceeded);
+
+	void OnChatSocketConnected();
+	void OnChatConnectionError(const FString& ErrorMessage);
+	void OnChatPacket(const FString& PacketJsonString);
+	void OnChatSocketClosed(int32 StatusCode, const FString& Reason, bool bWasClean);
+
+	void HandleChatMessagePacket(class FJsonObject* Payload);
+	void HandleChatMessageFragment(FString& MessageSoFar, class FJsonObject* Fragment);
+private:
+	TSharedRef<const FUniqueNetId> User;
+	FChatRoomId RoomId;
+	FString AuthKey;
+	TArray<FString> Endpoints;
+	TSharedPtr<class IWebSocket> WebSocket;
+	int32 ChannelId;
+	int32 MessageId;
+	bool bIsReady;
+};

--- a/Source/MixerInteractivity/Private/MixerChatConnection.h
+++ b/Source/MixerInteractivity/Private/MixerChatConnection.h
@@ -10,18 +10,22 @@ DECLARE_LOG_CATEGORY_EXTERN(LogMixerChat, Log, All);
 class FMixerChatConnection : public TSharedFromThis<FMixerChatConnection>
 {
 public:
-	FMixerChatConnection(const FUniqueNetId& UserId, const FChatRoomId& InRoomId, const FChatRoomConfig& Config)
-		: User(UserId.AsShared())
+	FMixerChatConnection(class FOnlineChatMixer* InChatInterface, const FUniqueNetId& UserId, const FChatRoomId& InRoomId, const FChatRoomConfig& Config)
+		: ChatInterface(InChatInterface)
+		, User(UserId.AsShared())
 		, RoomId(InRoomId)
 		, ChannelId(0)
 		, MessageId(0)
+		, ChatHistoryNum(0)
+		, ChatHistoryMax(10) // @TODO: pull from config once available
 		, bIsReady(false)
 		, bRejoinOnDisconnect(Config.bRejoinOnDisconnect)
 	{
 	}
 
+	virtual ~FMixerChatConnection();
+
 	bool Init();
-	void Cleanup();
 
 	bool SendChatMessage(const FString& MessageBody);
 	bool SendWhisper(const FString& ToUser, const FString& MessageBody);
@@ -30,6 +34,8 @@ public:
 	bool IsAnonymous() const					{ return AuthKey.IsEmpty(); }
 
 	void SetRejoinOnDisconnect(bool bInRejoin)	{ bRejoinOnDisconnect = bInRejoin; }
+
+	void GetMessageHistory(int32 NumMessages, TArray<TSharedRef<FChatMessage>>& OutMessages);
 
 private:
 
@@ -46,14 +52,34 @@ private:
 	void OnChatPacket(const FString& PacketJsonString);
 	void OnChatSocketClosed(int32 StatusCode, const FString& Reason, bool bWasClean);
 
-	void HandleChatMessagePacket(class FJsonObject* Payload);
-	void HandleChatMessageFragment(FString& MessageSoFar, class FJsonObject* Fragment);
+	void HandleChatEventDataObject(class FJsonObject* Payload, bool bSendEvents);
+	void HandleChatEventMessageFragment(FString& MessageSoFar, class FJsonObject* Fragment);
+
+	void DeleteFromChatHistoryIf(TFunctionRef<bool(TSharedPtr<struct FChatMessageMixerImpl>)> Predicate);
+
 private:
+	typedef void (FMixerChatConnection::*FReplyHandler)(class FJsonObject*);
+
+	void SendAuth(int32 ChannelId, const struct FMixerLocalUser* User, const FString& AuthKey);
+	void HandleAuthReply(class FJsonObject* Payload);
+
+	void SendHistory(int32 MessageCount);
+	void HandleHistoryReply(class FJsonObject* Payload);
+
+	void SendMethodPacket(const FString& Payload, FReplyHandler Handler);
+
+private:
+	class FOnlineChatMixer* ChatInterface;
 	TSharedRef<const FUniqueNetId> User;
 	FChatRoomId RoomId;
 	FString AuthKey;
 	TArray<FString> Endpoints;
 	TSharedPtr<class IWebSocket> WebSocket;
+	TMap<int32, FReplyHandler> ReplyHandlers;
+	TSharedPtr<struct FChatMessageMixerImpl> ChatHistoryNewest;
+	TSharedPtr<struct FChatMessageMixerImpl> ChatHistoryOldest;
+	int32 ChatHistoryNum;
+	int32 ChatHistoryMax;
 	int32 ChannelId;
 	int32 MessageId;
 	bool bIsReady;

--- a/Source/MixerInteractivity/Private/MixerChatConnection.h
+++ b/Source/MixerInteractivity/Private/MixerChatConnection.h
@@ -30,6 +30,8 @@ public:
 
 	bool SendChatMessage(const FString& MessageBody);
 	bool SendWhisper(const FString& ToUser, const FString& MessageBody);
+	bool SendVoteStart(const FString& Question, const TArray<FString>& Answers, FTimespan Duration);
+	bool SendVoteChoose(const FChatPollMixer& Poll, int32 AnswerIndex);
 
 	const FChatRoomId& GetRoom() const			{ return RoomId; }
 	bool IsAnonymous() const					{ return AuthKey.IsEmpty(); }
@@ -66,12 +68,14 @@ private:
 	bool HandleDeleteMessageEvent(class FJsonObject* JsonObj);
 	bool HandleClearMessagesEvent(class FJsonObject* JsonObj);
 	bool HandlePurgeMessageEvent(class FJsonObject* JsonObj);
-	bool HandlePollStartEvent(class FJsonObject* JsonObj, TSharedPtr<FChatMessageMixerImpl>& OutMessage);
-	bool HandlePollEndEvent(class FJsonObject* JsonObj, TSharedPtr<FChatMessageMixerImpl>& OutMessage);
+	bool HandlePollStartEvent(class FJsonObject* JsonObj);
+	bool HandlePollEndEvent(class FJsonObject* JsonObj);
 
 	bool HandleChatMessageEventInternal(class FJsonObject* JsonObj, TSharedPtr<FChatMessageMixerImpl>& OutMessage);
 	bool HandleChatMessageEventMessageObject(class FJsonObject* JsonObj, FChatMessageMixerImpl* ChatMessage);
 	bool HandleChatMessageEventMessageArrayEntry(class FJsonObject* JsonObj, FChatMessageMixerImpl* ChatMessage);
+	bool HandlePollEndEventInternal(class FJsonObject* JsonObj);
+	bool UpdateActivePollFromServer(class FJsonObject* JsonObj, bool& bOutAnythingChanged);
 
 	void AddMessageToChatHistory(TSharedRef<struct FChatMessageMixerImpl> ChatMessage);
 	void DeleteFromChatHistoryIf(TFunctionRef<bool(TSharedPtr<FChatMessageMixerImpl>)> Predicate);
@@ -98,6 +102,7 @@ private:
 	TSharedPtr<class IWebSocket> WebSocket;
 	TMap<FUniqueNetIdMixer, TSharedPtr<FMixerChatUser>> CachedUsers;
 	TMap<int32, FServerMessageHandler> ReplyHandlers;
+	TSharedPtr<struct FChatPollMixerImpl> ActivePoll;
 	TSharedPtr<struct FChatMessageMixerImpl> ChatHistoryNewest;
 	TSharedPtr<struct FChatMessageMixerImpl> ChatHistoryOldest;
 	int32 ChatHistoryNum;

--- a/Source/MixerInteractivity/Private/MixerChatConnection.h
+++ b/Source/MixerInteractivity/Private/MixerChatConnection.h
@@ -4,7 +4,7 @@
 #include "Interfaces/OnlineChatInterface.h"
 #include "Interfaces/IHttpRequest.h"
 #include "Interfaces/IHttpResponse.h"
-#include "MixerInteractivityModulePrivate.h"
+#include "OnlineChatMixerPrivate.h"
 
 DECLARE_LOG_CATEGORY_EXTERN(LogMixerChat, Log, All);
 

--- a/Source/MixerInteractivity/Private/MixerChatConnection.h
+++ b/Source/MixerInteractivity/Private/MixerChatConnection.h
@@ -1,3 +1,12 @@
+//*********************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+// THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
+// ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY
+// IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR
+// PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
+//
+//*********************************************************
 #pragma once
 
 #include "CoreMinimal.h"

--- a/Source/MixerInteractivity/Private/MixerChatConnection.h
+++ b/Source/MixerInteractivity/Private/MixerChatConnection.h
@@ -13,7 +13,9 @@ public:
 	FMixerChatConnection(const FUniqueNetId& UserId, const FChatRoomId& InRoomId)
 		: User(UserId.AsShared())
 		, RoomId(InRoomId)
+		, ChannelId(0)
 		, MessageId(0)
+		, bIsReady(false)
 	{
 	}
 

--- a/Source/MixerInteractivity/Private/MixerInteractivityModulePrivate.cpp
+++ b/Source/MixerInteractivity/Private/MixerInteractivityModulePrivate.cpp
@@ -1180,6 +1180,11 @@ TSharedPtr<IOnlineChat> FMixerInteractivityModule::GetChatInterface()
 	return ChatInterface;
 }
 
+TSharedPtr<IOnlineChatMixer> FMixerInteractivityModule::GetExtendedChatInterface()
+{
+	return ChatInterface;
+}
+
 #if PLATFORM_XBOXONE
 void FMixerInteractivityModule::TickXboxLogin()
 {

--- a/Source/MixerInteractivity/Private/MixerInteractivityModulePrivate.cpp
+++ b/Source/MixerInteractivity/Private/MixerInteractivityModulePrivate.cpp
@@ -12,6 +12,7 @@
 #include "MixerInteractivityUserSettings.h"
 #include "MixerDynamicDelegateBinding.h"
 #include "MixerInteractivityLog.h"
+#include "OnlineChatMixer.h"
 
 #include "HttpModule.h"
 #include "PlatformHttp.h"
@@ -30,6 +31,7 @@
 #include "SlateApplication.h"
 #include "App.h"
 #include "Engine/Engine.h"
+#include "OnlineSubsystemTypes.h"
 
 #if PLATFORM_SUPPORTS_MIXER_OAUTH
 #include "SMixerLoginPane.h"
@@ -71,6 +73,8 @@ void FMixerInteractivityModule::StartupModule()
 	InteractivityState = EMixerInteractivityState::Not_Interactive;
 	ClientLibraryState = Microsoft::mixer::not_initialized;
 	HasCreatedGroups = false;
+
+	ChatInterface = MakeShared<FOnlineChatMixer>();
 }
 
 bool FMixerInteractivityModule::LoginSilently(TSharedPtr<const FUniqueNetId> UserId)
@@ -1172,6 +1176,10 @@ void FMixerInteractivityModule::InitDesignTimeGroups()
 	}
 }
 
+TSharedPtr<IOnlineChat> FMixerInteractivityModule::GetChatInterface()
+{
+	return ChatInterface;
+}
 
 #if PLATFORM_XBOXONE
 void FMixerInteractivityModule::TickXboxLogin()

--- a/Source/MixerInteractivity/Private/MixerInteractivityModulePrivate.cpp
+++ b/Source/MixerInteractivity/Private/MixerInteractivityModulePrivate.cpp
@@ -653,11 +653,10 @@ void FMixerInteractivityModule::OnTokenRequestComplete(FHttpRequestPtr HttpReque
 	{
 		// Now get user info
 		const UMixerInteractivityUserSettings* UserSettings = GetDefault<UMixerInteractivityUserSettings>();
-		FString AuthZHeaderValue = FString::Printf(TEXT("Bearer %s"), *UserSettings->AccessToken);
 		TSharedRef<IHttpRequest> UserRequest = FHttpModule::Get().CreateRequest();
 		UserRequest->SetVerb(TEXT("GET"));
 		UserRequest->SetURL(TEXT("https://mixer.com/api/v1/users/current"));
-		UserRequest->SetHeader(TEXT("Authorization"), AuthZHeaderValue);
+		UserRequest->SetHeader(TEXT("Authorization"), UserSettings->GetAuthZHeaderValue());
 		UserRequest->OnProcessRequestComplete().BindRaw(this, &FMixerInteractivityModule::OnUserRequestComplete);
 		if (!UserRequest->ProcessRequest())
 		{
@@ -1193,10 +1192,13 @@ void FMixerInteractivityModule::TickXboxLogin()
 			{
 				if (GetXTokenOperation->Status == Windows::Foundation::AsyncStatus::Completed)
 				{
+					UMixerInteractivityUserSettings* UserSettings = GetMutableDefault<UMixerInteractivityUserSettings>();
+					UserSettings->AccessToken = GetXTokenOperation->GetResults()->Token->ToString()->Data();
+
 					TSharedRef<IHttpRequest> UserRequest = FHttpModule::Get().CreateRequest();
 					UserRequest->SetVerb(TEXT("GET"));
 					UserRequest->SetURL(TEXT("https://mixer.com/api/v1/users/current"));
-					UserRequest->SetHeader(TEXT("Authorization"), GetXTokenOperation->GetResults()->Token->ToString()->Data());
+					UserRequest->SetHeader(TEXT("Authorization"), UserSettings->GetAuthZHeaderValue());
 					UserRequest->OnProcessRequestComplete().BindRaw(this, &FMixerInteractivityModule::OnUserRequestComplete);
 					if (!UserRequest->ProcessRequest())
 					{

--- a/Source/MixerInteractivity/Private/MixerInteractivityModulePrivate.h
+++ b/Source/MixerInteractivity/Private/MixerInteractivityModulePrivate.h
@@ -27,6 +27,7 @@
 #include "JsonSerializerMacros.h"
 #include "Future.h"
 #include "Input/Reply.h"
+#include "CoreOnline.h"
 #include <memory>
 
 namespace Microsoft
@@ -74,6 +75,49 @@ public:
 		: RefreshAtAppTime(0.0)
 	{
 	}
+};
+
+class FUniqueNetIdMixer : public FUniqueNetId
+{
+public:
+	FUniqueNetIdMixer(int32 InMixerId)
+		: MixerId(InMixerId)
+	{
+
+	}
+
+	virtual const uint8* GetBytes() const override
+	{
+		return reinterpret_cast<const uint8*>(&MixerId);
+	}
+
+	virtual int32 GetSize() const override
+	{
+		return sizeof(MixerId);
+	}
+
+	virtual bool IsValid() const override
+	{
+		return MixerId != 0;
+	}
+
+	virtual FString ToString() const
+	{
+		return FString::Printf(TEXT("%d"), MixerId);
+	}
+
+	virtual FString ToDebugString() const override
+	{
+		return FString::Printf(TEXT("MixerId: %d"), MixerId);
+	}
+
+	friend uint32 GetTypeHash(const FUniqueNetIdMixer& Unid)
+	{
+		return GetTypeHash(Unid.MixerId);
+	}
+
+private:
+	int32 MixerId;
 };
 
 struct FMixerRemoteUserCached : public FMixerRemoteUser

--- a/Source/MixerInteractivity/Private/MixerInteractivityModulePrivate.h
+++ b/Source/MixerInteractivity/Private/MixerInteractivityModulePrivate.h
@@ -44,6 +44,7 @@ struct FMixerChannelJsonSerializable : public FMixerChannel, public FJsonSeriali
 {
 public:
 	BEGIN_JSON_SERIALIZER
+		JSON_SERIALIZE("id", Id);
 		JSON_SERIALIZE("name", Name);
 		JSON_SERIALIZE("viewersCurrent", CurrentViewers);
 		JSON_SERIALIZE("viewersTotal", LifetimeUniqueViewers);
@@ -132,6 +133,8 @@ public:
 	virtual bool MoveParticipantToGroup(FName GroupName, uint32 ParticipantId);
 	virtual void CaptureSparkTransaction(const FString& TransactionId);
 
+	virtual TSharedPtr<IOnlineChat> GetChatInterface();
+
 	virtual FOnLoginStateChanged& OnLoginStateChanged()						{ return LoginStateChanged; }
 	virtual FOnInteractivityStateChanged& OnInteractivityStateChanged()		{ return InteractivityStateChanged; }
 	virtual FOnParticipantStateChangedEvent& OnParticipantStateChanged()	{ return ParticipantStateChanged; }
@@ -193,6 +196,8 @@ private:
 	FOnButtonEvent ButtonEvent;
 	FOnStickEvent StickEvent;
 	FOnBroadcastingStateChanged BroadcastingStateChanged;
+
+	TSharedPtr<class FOnlineChatMixer> ChatInterface;
 
 	bool RetryLoginWithUI;
 	bool HasCreatedGroups;

--- a/Source/MixerInteractivity/Private/MixerInteractivityModulePrivate.h
+++ b/Source/MixerInteractivity/Private/MixerInteractivityModulePrivate.h
@@ -77,49 +77,6 @@ public:
 	}
 };
 
-class FUniqueNetIdMixer : public FUniqueNetId
-{
-public:
-	FUniqueNetIdMixer(int32 InMixerId)
-		: MixerId(InMixerId)
-	{
-
-	}
-
-	virtual const uint8* GetBytes() const override
-	{
-		return reinterpret_cast<const uint8*>(&MixerId);
-	}
-
-	virtual int32 GetSize() const override
-	{
-		return sizeof(MixerId);
-	}
-
-	virtual bool IsValid() const override
-	{
-		return MixerId != 0;
-	}
-
-	virtual FString ToString() const
-	{
-		return FString::Printf(TEXT("%d"), MixerId);
-	}
-
-	virtual FString ToDebugString() const override
-	{
-		return FString::Printf(TEXT("MixerId: %d"), MixerId);
-	}
-
-	friend uint32 GetTypeHash(const FUniqueNetIdMixer& Unid)
-	{
-		return GetTypeHash(Unid.MixerId);
-	}
-
-private:
-	int32 MixerId;
-};
-
 struct FMixerRemoteUserCached : public FMixerRemoteUser
 {
 public:
@@ -177,7 +134,8 @@ public:
 	virtual bool MoveParticipantToGroup(FName GroupName, uint32 ParticipantId);
 	virtual void CaptureSparkTransaction(const FString& TransactionId);
 
-	virtual TSharedPtr<IOnlineChat> GetChatInterface();
+	virtual TSharedPtr<class IOnlineChat> GetChatInterface();
+	virtual TSharedPtr<class IOnlineChatMixer> GetExtendedChatInterface();
 
 	virtual FOnLoginStateChanged& OnLoginStateChanged()						{ return LoginStateChanged; }
 	virtual FOnInteractivityStateChanged& OnInteractivityStateChanged()		{ return InteractivityStateChanged; }

--- a/Source/MixerInteractivity/Private/OnlineChatMixer.cpp
+++ b/Source/MixerInteractivity/Private/OnlineChatMixer.cpp
@@ -163,7 +163,5 @@ bool FOnlineChatMixer::IsDefaultChatRoom(const FChatRoomId& RoomId) const
 bool FOnlineChatMixer::WillJoinAnonymously() const
 {
 	TSharedPtr<const FMixerLocalUser> CurrentUser = IMixerInteractivityModule::Get().GetCurrentUser();
-	// @TODO: currently chat auth assumes the presence of an oauth token.
-	// Update once we also support xtoken.
 	return !CurrentUser.IsValid();
 }

--- a/Source/MixerInteractivity/Private/OnlineChatMixer.cpp
+++ b/Source/MixerInteractivity/Private/OnlineChatMixer.cpp
@@ -1,3 +1,12 @@
+//*********************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+// THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
+// ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY
+// IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR
+// PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
+//
+//*********************************************************
 #include "OnlineChatMixer.h"
 
 #include "MixerInteractivityModule.h"

--- a/Source/MixerInteractivity/Private/OnlineChatMixer.cpp
+++ b/Source/MixerInteractivity/Private/OnlineChatMixer.cpp
@@ -165,5 +165,5 @@ bool FOnlineChatMixer::WillJoinAnonymously() const
 	TSharedPtr<const FMixerLocalUser> CurrentUser = IMixerInteractivityModule::Get().GetCurrentUser();
 	// @TODO: currently chat auth assumes the presence of an oauth token.
 	// Update once we also support xtoken.
-	return !CurrentUser.IsValid() || !PLATFORM_SUPPORTS_MIXER_OAUTH;
+	return !CurrentUser.IsValid();
 }

--- a/Source/MixerInteractivity/Private/OnlineChatMixer.cpp
+++ b/Source/MixerInteractivity/Private/OnlineChatMixer.cpp
@@ -96,8 +96,7 @@ bool FOnlineChatMixer::SendRoomChat(const FUniqueNetId& UserId, const FChatRoomI
 	TSharedPtr<FMixerChatConnection> Connection = FindConnectionForRoomId(RoomId);
 	if (Connection.IsValid())
 	{
-		Connection->SendChatMessage(MsgBody);
-		return true;
+		return Connection->SendChatMessage(MsgBody);
 	}
 	else
 	{

--- a/Source/MixerInteractivity/Private/OnlineChatMixer.cpp
+++ b/Source/MixerInteractivity/Private/OnlineChatMixer.cpp
@@ -179,6 +179,33 @@ bool FOnlineChatMixer::GetLastMessages(const FUniqueNetId& UserId, const FChatRo
 	}
 }
 
+bool FOnlineChatMixer::StartPoll(const FUniqueNetId& UserId, const FChatRoomId& RoomId, const FString& Question, const TArray<FString>& Answers, FTimespan Duration)
+{
+	TSharedPtr<FMixerChatConnection> Connection = FindConnectionForRoomId(RoomId);
+	if (Connection.IsValid())
+	{
+		return Connection->SendVoteStart(Question, Answers, Duration);
+	}
+	else
+	{
+		return false;
+	}
+}
+
+bool FOnlineChatMixer::VoteInPoll(const FUniqueNetId& UserId, const FChatRoomId& RoomId, const FChatPollMixer& Poll, int32 AnswerIndex)
+{
+	TSharedPtr<FMixerChatConnection> Connection = FindConnectionForRoomId(RoomId);
+	if (Connection.IsValid())
+	{
+		return Connection->SendVoteChoose(Poll, AnswerIndex);
+	}
+	else
+	{
+		return false;
+	}
+}
+
+
 
 bool FOnlineChatMixer::IsDefaultChatRoom(const FChatRoomId& RoomId) const
 {

--- a/Source/MixerInteractivity/Private/OnlineChatMixer.cpp
+++ b/Source/MixerInteractivity/Private/OnlineChatMixer.cpp
@@ -1,0 +1,169 @@
+#include "OnlineChatMixer.h"
+
+#include "MixerInteractivityModule.h"
+#include "MixerInteractivityTypes.h"
+#include "MixerInteractivityUserSettings.h"
+#include "MixerChatConnection.h"
+
+bool FOnlineChatMixer::JoinPublicRoom(const FUniqueNetId& UserId, const FChatRoomId& RoomId, const FString& Nickname, const FChatRoomConfig& ChatRoomConfig)
+{
+	TSharedPtr<FMixerChatConnection> NewConnection;
+
+	if (IsDefaultChatRoom(RoomId))
+	{
+		if (DefaultChatConnection.IsValid())
+		{
+			if (DefaultChatConnection->IsAnonymous() && !WillJoinAnonymously())
+			{
+				// Allow upgrade to an auth'd connection.
+				DefaultChatConnection->Cleanup();
+			}
+			else
+			{
+				// Already joined, no point in rejoining.
+				UE_LOG(LogMixerChat, Warning, TEXT("A connection to room %s already exists."), *DefaultChatConnection->GetRoom());
+				return false;
+			}
+		}
+
+		TSharedPtr<const FMixerLocalUser> CurrentUser = IMixerInteractivityModule::Get().GetCurrentUser();
+		check(CurrentUser.IsValid());
+		NewConnection = DefaultChatConnection = MakeShared<FMixerChatConnection>(UserId, CurrentUser->Name);
+	}
+	else
+	{
+		if (RoomId.IsEmpty())
+		{
+			UE_LOG(LogMixerChat, Warning, TEXT("Joining chat without logging in requires explicitly specifying a room id (use the owner's Mixer user name)."))
+			return false;
+		}
+
+		for (TSharedRef<FMixerChatConnection>& Connection : AdditionalChatConnections)
+		{
+			if (Connection->GetRoom() == RoomId)
+			{
+				if (Connection->IsAnonymous() && !WillJoinAnonymously())
+				{
+					// Allow upgrade to an auth'd connection.
+					Connection->Cleanup();
+					NewConnection = Connection = MakeShared<FMixerChatConnection>(UserId, RoomId);
+					break;
+				}
+				else
+				{
+					UE_LOG(LogMixerChat, Warning, TEXT("A connection to room %s already exists."), *RoomId);
+					return false;
+				}
+			}
+		}
+
+		if (!NewConnection.IsValid())
+		{
+			NewConnection = MakeShared<FMixerChatConnection>(UserId, RoomId);
+			AdditionalChatConnections.Add(NewConnection.ToSharedRef());
+		}
+	}
+
+	bool bStartedConnection = NewConnection->Init();
+	if (!bStartedConnection)
+	{
+		UE_LOG(LogMixerChat, Warning, TEXT("Error initializing connection sequence for room %s."), *RoomId);
+		NewConnection->Cleanup();
+		if (NewConnection == DefaultChatConnection)
+		{
+			DefaultChatConnection.Reset();
+		}
+		else
+		{
+			AdditionalChatConnections.Remove(NewConnection.ToSharedRef());
+		}
+	}
+
+	return bStartedConnection;
+}
+
+bool FOnlineChatMixer::SendRoomChat(const FUniqueNetId& UserId, const FChatRoomId& RoomId, const FString& MsgBody)
+{
+	if (IsDefaultChatRoom(RoomId))
+	{
+		if (DefaultChatConnection.IsValid())
+		{
+			return DefaultChatConnection->SendChatMessage(MsgBody);
+		}
+		else
+		{
+			return false;
+		}
+	}
+
+	for (TSharedRef<FMixerChatConnection>& Connection : AdditionalChatConnections)
+	{
+		if (Connection->GetRoom() == RoomId)
+		{
+			return Connection->SendChatMessage(MsgBody);
+		}
+	}
+
+	return false;
+}
+
+bool FOnlineChatMixer::SendPrivateChat(const FUniqueNetId& UserId, const FUniqueNetId& RecipientId, const FString& MsgBody)
+{
+	// Currently the recipient must be in the default chat room
+	if (DefaultChatConnection.IsValid())
+	{
+		return DefaultChatConnection->SendWhisper(RecipientId.ToString(), MsgBody);
+	}
+
+	return false;
+}
+
+bool FOnlineChatMixer::IsChatAllowed(const FUniqueNetId& UserId, const FUniqueNetId& RecipientId) const
+{
+	// We can only send private messages in the default chat room.
+	// We can't send messages if logged in anonymously.
+	// @TODO: permissions check.
+	return DefaultChatConnection.IsValid() && !DefaultChatConnection->IsAnonymous();
+}
+
+void FOnlineChatMixer::GetJoinedRooms(const FUniqueNetId& UserId, TArray<FChatRoomId>& OutRooms)
+{
+	if (DefaultChatConnection.IsValid())
+	{
+		OutRooms.Add(DefaultChatConnection->GetRoom());
+	}
+
+	for (TSharedRef<FMixerChatConnection>& Connection : AdditionalChatConnections)
+	{
+		OutRooms.Add(Connection->GetRoom());
+	}
+}
+
+TSharedPtr<FChatRoomInfo> FOnlineChatMixer::GetRoomInfo(const FUniqueNetId& UserId, const FChatRoomId& RoomId)
+{
+	return nullptr;
+}
+
+bool FOnlineChatMixer::IsDefaultChatRoom(const FChatRoomId& RoomId) const
+{
+	TSharedPtr<const FMixerLocalUser> CurrentUser = IMixerInteractivityModule::Get().GetCurrentUser();
+	if (!CurrentUser.IsValid())
+	{
+		return false;
+	}
+
+	if (RoomId.IsEmpty())
+	{
+		return true;
+	}
+
+	return RoomId == CurrentUser->Name;
+}
+
+bool FOnlineChatMixer::WillJoinAnonymously() const
+{
+	TSharedPtr<const FMixerLocalUser> CurrentUser = IMixerInteractivityModule::Get().GetCurrentUser();
+	// @TODO: currently chat auth assumes the presence of an oauth token.
+	// Update once we also support xtoken.
+	return !CurrentUser.IsValid() || !PLATFORM_SUPPORTS_MIXER_OAUTH;
+}

--- a/Source/MixerInteractivity/Private/OnlineChatMixer.cpp
+++ b/Source/MixerInteractivity/Private/OnlineChatMixer.cpp
@@ -35,7 +35,7 @@ bool FOnlineChatMixer::JoinPublicRoom(const FUniqueNetId& UserId, const FChatRoo
 
 		TSharedPtr<const FMixerLocalUser> CurrentUser = IMixerInteractivityModule::Get().GetCurrentUser();
 		check(CurrentUser.IsValid());
-		NewConnection = DefaultChatConnection = MakeShared<FMixerChatConnection>(UserId, CurrentUser->Name);
+		NewConnection = DefaultChatConnection = MakeShared<FMixerChatConnection>(UserId, CurrentUser->Name, ChatRoomConfig);
 	}
 	else
 	{
@@ -53,7 +53,7 @@ bool FOnlineChatMixer::JoinPublicRoom(const FUniqueNetId& UserId, const FChatRoo
 				{
 					// Allow upgrade to an auth'd connection.
 					Connection->Cleanup();
-					NewConnection = Connection = MakeShared<FMixerChatConnection>(UserId, RoomId);
+					NewConnection = Connection = MakeShared<FMixerChatConnection>(UserId, RoomId, ChatRoomConfig);
 					break;
 				}
 				else
@@ -66,7 +66,7 @@ bool FOnlineChatMixer::JoinPublicRoom(const FUniqueNetId& UserId, const FChatRoo
 
 		if (!NewConnection.IsValid())
 		{
-			NewConnection = MakeShared<FMixerChatConnection>(UserId, RoomId);
+			NewConnection = MakeShared<FMixerChatConnection>(UserId, RoomId, ChatRoomConfig);
 			AdditionalChatConnections.Add(NewConnection.ToSharedRef());
 		}
 	}

--- a/Source/MixerInteractivity/Private/OnlineChatMixerPrivate.h
+++ b/Source/MixerInteractivity/Private/OnlineChatMixerPrivate.h
@@ -1,0 +1,190 @@
+#pragma once
+
+#include "OnlineChatMixer.h"
+#include "MixerInteractivityTypes.h"
+#include "Guid.h"
+
+class FUniqueNetIdMixer : public FUniqueNetId
+{
+public:
+	FUniqueNetIdMixer(int32 InMixerId)
+		: MixerId(InMixerId)
+	{
+
+	}
+
+	virtual const uint8* GetBytes() const override
+	{
+		return reinterpret_cast<const uint8*>(&MixerId);
+	}
+
+	virtual int32 GetSize() const override
+	{
+		return sizeof(MixerId);
+	}
+
+	virtual bool IsValid() const override
+	{
+		return MixerId != 0;
+	}
+
+	virtual FString ToString() const
+	{
+		return FString::Printf(TEXT("%d"), MixerId);
+	}
+
+	virtual FString ToDebugString() const override
+	{
+		return FString::Printf(TEXT("MixerId: %d"), MixerId);
+	}
+
+	friend uint32 GetTypeHash(const FUniqueNetIdMixer& Unid)
+	{
+		return GetTypeHash(Unid.MixerId);
+	}
+
+private:
+	int32 MixerId;
+};
+
+struct FMixerChatUser : public FMixerUser
+{
+public:
+	FMixerChatUser(const FString& InName, int32 InId)
+		: NetId(MakeShared<FUniqueNetIdMixer>(Id))
+	{
+		Name = InName;
+		Id = InId;
+		Level = 0;
+	}
+
+	const FUniqueNetIdMixer& GetUniqueNetId() const { return static_cast<const FUniqueNetIdMixer&>(NetId.Get()); }
+
+	// FChatMessage wants a old-fashioned shared ref to a net id.  Most other OSS types operate in terms
+	// of native references these days.  Look for opportunities to remove this method if things change.
+	const TSharedRef<const FUniqueNetId>& GetUniqueNetIdForChatMessage() const { return NetId; }
+
+private:
+	TSharedRef<const FUniqueNetId> NetId;
+};
+
+struct FChatMessageMixerImpl : public FChatMessageMixer
+{
+public:
+	FChatMessageMixerImpl(const FGuid& InMessageId, TSharedRef<const FMixerChatUser> InFromUser)
+		: MessageId(InMessageId)
+		, FromUser(InFromUser)
+		, Timestamp(FDateTime::Now())
+		, bIsWhisper(false)
+		, bIsAction(false)
+		, bIsModerated(false)
+	{
+	}
+
+	// FChatMessage methods
+	virtual const TSharedRef<const FUniqueNetId>& GetUserId() const override	{ return FromUser->GetUniqueNetIdForChatMessage(); }
+	virtual const FString& GetNickname() const override							{ return FromUser->Name; }
+	virtual const FString& GetBody() const override								{ return Body; }
+	virtual const FDateTime& GetTimestamp() const override						{ return Timestamp; }
+
+	// FChatMessageMixer methods
+	virtual bool IsWhisper() override											{ return bIsWhisper; }
+	virtual bool IsAction() override											{ return bIsAction; }
+	virtual bool IsModerated() override											{ return bIsModerated; }
+
+	const FMixerChatUser& GetSender()											{ return FromUser.Get(); }
+	const FGuid& GetMessageId()													{ return MessageId; }
+
+	void FlagAsDeleted()
+	{
+		Body.Empty();
+		bIsModerated = true;
+	}
+
+	void AppendBodyFragment(const FString& InBodyFragment)
+	{
+		Body += InBodyFragment;
+	}
+
+	void FlagAsWhisper()
+	{
+		bIsWhisper = true;
+	}
+
+	void FlagAsAction()
+	{
+		if (!bIsAction)
+		{
+			bIsAction = true;
+			Body = FromUser->Name + TEXT(" ") + Body;
+		}
+	}
+
+private:
+	FGuid MessageId;
+	TSharedRef<const FMixerChatUser> FromUser;
+	FString Body;
+	FDateTime Timestamp;
+	bool bIsWhisper;
+	bool bIsAction;
+	bool bIsModerated;
+
+public:
+	// Intrusive list to avoid double allocation for chat history
+	// Would be nice to use TIntrusiveList, but that doesn't support
+	// TSharedPtr as the link type, and IOnlineChat enforces that the
+	// lifetime is managed by TSharedPtr
+	TSharedPtr<FChatMessageMixerImpl> NextLink;
+	TSharedPtr<FChatMessageMixerImpl> PrevLink;
+};
+
+class FOnlineChatMixer : public IOnlineChatMixer, public TSharedFromThis<FOnlineChatMixer>
+{
+public:
+	virtual bool CreateRoom(const FUniqueNetId& UserId, const FChatRoomId& RoomId, const FString& Nickname, const FChatRoomConfig& ChatRoomConfig) override;
+
+	virtual bool ConfigureRoom(const FUniqueNetId& UserId, const FChatRoomId& RoomId, const FChatRoomConfig& ChatRoomConfig) override { return false; }
+
+	virtual bool JoinPublicRoom(const FUniqueNetId& UserId, const FChatRoomId& RoomId, const FString& Nickname, const FChatRoomConfig& ChatRoomConfig) override;
+
+	virtual bool JoinPrivateRoom(const FUniqueNetId& UserId, const FChatRoomId& RoomId, const FString& Nickname, const FChatRoomConfig& ChatRoomConfig) override { return false; }
+
+	virtual bool ExitRoom(const FUniqueNetId& UserId, const FChatRoomId& RoomId) override;
+
+	virtual bool SendRoomChat(const FUniqueNetId& UserId, const FChatRoomId& RoomId, const FString& MsgBody) override;
+
+	virtual bool SendPrivateChat(const FUniqueNetId& UserId, const FUniqueNetId& RecipientId, const FString& MsgBody) override;
+
+	virtual bool IsChatAllowed(const FUniqueNetId& UserId, const FUniqueNetId& RecipientId) const override;
+
+	virtual void GetJoinedRooms(const FUniqueNetId& UserId, TArray<FChatRoomId>& OutRooms) override;
+
+	virtual TSharedPtr<FChatRoomInfo> GetRoomInfo(const FUniqueNetId& UserId, const FChatRoomId& RoomId) override;
+
+	virtual bool GetMembers(const FUniqueNetId& UserId, const FChatRoomId& RoomId, TArray< TSharedRef<FChatRoomMember> >& OutMembers) override { return false; }
+
+	virtual TSharedPtr<FChatRoomMember> GetMember(const FUniqueNetId& UserId, const FChatRoomId& RoomId, const FUniqueNetId& MemberId) override { return false; }
+
+	virtual bool GetLastMessages(const FUniqueNetId& UserId, const FChatRoomId& RoomId, int32 NumMessages, TArray< TSharedRef<FChatMessage> >& OutMessages) override;
+
+	virtual void DumpChatState() const override {}
+
+public:
+	void ConnectAttemptFinished(const FUniqueNetId& UserId, const FChatRoomId& RoomId, bool bSuccess, const FString& ErrorMessage);
+	bool ExitRoomWithReason(const FUniqueNetId& UserId, const FChatRoomId& RoomId, bool bIsClean, const FString& Reason);
+
+private:
+
+	bool IsDefaultChatRoom(const FChatRoomId& RoomId) const;
+	bool WillJoinAnonymously() const;
+	bool RemoveConnectionForRoom(const FChatRoomId& RoomId);
+
+	/**
+	* Connection to the default chat channel for the current Mixer session -
+	* that is, the channel owned by the current Mixer user.
+	*/
+	TSharedPtr<class FMixerChatConnection> DefaultChatConnection;
+
+	/** Connection to additional chat channels that we may want to interact with. */
+	TArray<TSharedRef<class FMixerChatConnection>> AdditionalChatConnections;
+};

--- a/Source/MixerInteractivity/Private/OnlineChatMixerPrivate.h
+++ b/Source/MixerInteractivity/Private/OnlineChatMixerPrivate.h
@@ -1,3 +1,12 @@
+//*********************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+// THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
+// ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY
+// IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR
+// PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
+//
+//*********************************************************
 #pragma once
 
 #include "OnlineChatMixer.h"

--- a/Source/MixerInteractivity/Private/SMixerLoginPane.cpp
+++ b/Source/MixerInteractivity/Private/SMixerLoginPane.cpp
@@ -123,9 +123,9 @@ void SMixerLoginPane::StartLoginFlowAfterCookiesDeleted()
 	if (BrowserWidget.IsValid())
 	{
 #if WITH_EDITOR
-		static const FString OAuthScope = GIsEditor ? "interactive:manage:self interactive:robot:self" : "interactive:robot:self";
+		static const FString OAuthScope = GIsEditor ? "interactive:manage:self interactive:robot:self chat:connect chat:chat chat:whisper" : "interactive:robot:self chat:connect chat:chat chat:whisper";
 #else
-		static const FString OAuthScope = "interactive:robot:self";
+		static const FString OAuthScope = "interactive:robot:self chat:connect chat:chat chat:whisper";
 #endif
 
 		const UMixerInteractivitySettings* Settings = GetDefault<UMixerInteractivitySettings>();

--- a/Source/MixerInteractivity/Public/MixerInteractivityModule.h
+++ b/Source/MixerInteractivity/Public/MixerInteractivityModule.h
@@ -274,6 +274,14 @@ public:
 	*/
 	virtual void CaptureSparkTransaction(const FString& TransactionId) = 0;
 
+	/**
+	* Get access to Mixer chat via UE's standard IOnlineChat interface.
+	* Sending messages requires a logged in user and is not yet supported on all platforms.
+	*
+	* @Return					See FOnlineChatMixer.
+	*/
+	virtual TSharedPtr<class IOnlineChat> GetChatInterface() = 0;
+
 	// Events
 	DECLARE_EVENT_OneParam(IMixerInteractivityModule, FOnLoginStateChanged, EMixerLoginState);
 	virtual FOnLoginStateChanged& OnLoginStateChanged() = 0;

--- a/Source/MixerInteractivity/Public/MixerInteractivityModule.h
+++ b/Source/MixerInteractivity/Public/MixerInteractivityModule.h
@@ -276,11 +276,20 @@ public:
 
 	/**
 	* Get access to Mixer chat via UE's standard IOnlineChat interface.
-	* Sending messages requires a logged in user and is not yet supported on all platforms.
+	* Sending messages requires a logged in user.
 	*
-	* @Return					See FOnlineChatMixer.
+	* @Return					See IOnlineChat.
 	*/
 	virtual TSharedPtr<class IOnlineChat> GetChatInterface() = 0;
+
+	/**
+	* Get access to Mixer chat via IOnlineChatMixer which supports additional
+	* interactions that extend the standard IOnlineChat interface.
+	* Sending messages requires a logged in user.
+	*
+	* @Return					See IOnlineChatMixer.
+	*/
+	virtual TSharedPtr<class IOnlineChatMixer> GetExtendedChatInterface() = 0;
 
 	// Events
 	DECLARE_EVENT_OneParam(IMixerInteractivityModule, FOnLoginStateChanged, EMixerLoginState);

--- a/Source/MixerInteractivity/Public/MixerInteractivityTypes.h
+++ b/Source/MixerInteractivity/Public/MixerInteractivityTypes.h
@@ -38,6 +38,9 @@ public:
 	/** A name for the channel, suitable for display in game UI */
 	FString Name;
 
+	/** Unique identifier, for internal use */
+	int32 Id;
+
 	/** 
 	* The number of users currently viewing this channel 
 	* Note: this value is periodically updated from the Mixer service.

--- a/Source/MixerInteractivity/Public/MixerInteractivityTypes.h
+++ b/Source/MixerInteractivity/Public/MixerInteractivityTypes.h
@@ -29,6 +29,16 @@ public:
 	int32 Level;
 
 	FMixerUser();
+
+	bool operator==(const FMixerUser& Other) const
+	{
+		return Id == Other.Id;
+	}
+
+	bool operator!=(const FMixerUser& Other) const
+	{
+		return Id != Other.Id;
+	}
 };
 
 /** Information about a channel owned by a user on Mixer */

--- a/Source/MixerInteractivity/Public/MixerInteractivityUserSettings.h
+++ b/Source/MixerInteractivity/Public/MixerInteractivityUserSettings.h
@@ -24,4 +24,13 @@ public:
 
 	UPROPERTY(Transient)
 	FString AccessToken;
+
+public:
+
+	FString GetAuthZHeaderValue() const
+	{
+		return (!AccessToken.IsEmpty() && PLATFORM_SUPPORTS_MIXER_OAUTH)
+			? FString(TEXT("Bearer ")) + AccessToken
+			: AccessToken;
+	}
 };

--- a/Source/MixerInteractivity/Public/OnlineChatMixer.h
+++ b/Source/MixerInteractivity/Public/OnlineChatMixer.h
@@ -40,7 +40,7 @@ private:
 class FOnlineChatMixer : public IOnlineChat, public TSharedFromThis<FOnlineChatMixer>
 {
 public:
-	virtual bool CreateRoom(const FUniqueNetId& UserId, const FChatRoomId& RoomId, const FString& Nickname, const FChatRoomConfig& ChatRoomConfig) override { return false; }
+	virtual bool CreateRoom(const FUniqueNetId& UserId, const FChatRoomId& RoomId, const FString& Nickname, const FChatRoomConfig& ChatRoomConfig) override;
 
 	virtual bool ConfigureRoom(const FUniqueNetId& UserId, const FChatRoomId& RoomId, const FChatRoomConfig& ChatRoomConfig) override { return false; }
 
@@ -48,7 +48,7 @@ public:
 
 	virtual bool JoinPrivateRoom(const FUniqueNetId& UserId, const FChatRoomId& RoomId, const FString& Nickname, const FChatRoomConfig& ChatRoomConfig) override { return false; }
 
-	virtual bool ExitRoom(const FUniqueNetId& UserId, const FChatRoomId& RoomId) override { return false; }
+	virtual bool ExitRoom(const FUniqueNetId& UserId, const FChatRoomId& RoomId) override;
 
 	virtual bool SendRoomChat(const FUniqueNetId& UserId, const FChatRoomId& RoomId, const FString& MsgBody) override;
 

--- a/Source/MixerInteractivity/Public/OnlineChatMixer.h
+++ b/Source/MixerInteractivity/Public/OnlineChatMixer.h
@@ -17,57 +17,32 @@ public:
 };
 
 /**
-* Implementation of IOnlineChat for Mixer.
-* Rooms map to Mixer channels and are identified by the username of their owner.
-* See IOnlineChat for interface method details.
+* Delegate used when all messages in a chat room are deleted
+*
+* @param UserId user currently in the room
+* @param RoomId room that member is in
 */
-class FOnlineChatMixer : public IOnlineChat, public TSharedFromThis<FOnlineChatMixer>
+DECLARE_MULTICAST_DELEGATE_TwoParams(FOnChatRoomMessagesCleared, const FUniqueNetId& /*UserId*/, const FChatRoomId& /*RoomId*/);
+typedef FOnChatRoomMessagesCleared::FDelegate FOnChatRoomMessagesClearedDelegate;
+
+/**
+* Delegate used when a user is purged from a chat room (all messages deleted)
+*
+* @param UserId user currently in the room
+* @param RoomId room that member is in
+* @param PurgedId user that has been purged
+*/
+DECLARE_MULTICAST_DELEGATE_ThreeParams(FOnChatRoomUserPurged, const FUniqueNetId& /*UserId*/, const FChatRoomId& /*RoomId*/, const FUniqueNetId& /*PurgedId*/);
+typedef FOnChatRoomUserPurged::FDelegate FOnChatRoomUserPurgedDelegate;
+
+/**
+* Extension of IOnlineChat for Mixer.
+* Rooms map to Mixer channels and are identified by the username of their owner.
+*/
+class IOnlineChatMixer : public IOnlineChat
 {
 public:
-	virtual bool CreateRoom(const FUniqueNetId& UserId, const FChatRoomId& RoomId, const FString& Nickname, const FChatRoomConfig& ChatRoomConfig) override;
+	DEFINE_ONLINE_DELEGATE_TWO_PARAM(OnChatRoomMessagesCleared, const FUniqueNetId&, const FChatRoomId&);
+	DEFINE_ONLINE_DELEGATE_THREE_PARAM(OnChatRoomUserPurged, const FUniqueNetId&, const FChatRoomId&, const FUniqueNetId&);
 
-	virtual bool ConfigureRoom(const FUniqueNetId& UserId, const FChatRoomId& RoomId, const FChatRoomConfig& ChatRoomConfig) override { return false; }
-
-	virtual bool JoinPublicRoom(const FUniqueNetId& UserId, const FChatRoomId& RoomId, const FString& Nickname, const FChatRoomConfig& ChatRoomConfig) override;
-
-	virtual bool JoinPrivateRoom(const FUniqueNetId& UserId, const FChatRoomId& RoomId, const FString& Nickname, const FChatRoomConfig& ChatRoomConfig) override { return false; }
-
-	virtual bool ExitRoom(const FUniqueNetId& UserId, const FChatRoomId& RoomId) override;
-
-	virtual bool SendRoomChat(const FUniqueNetId& UserId, const FChatRoomId& RoomId, const FString& MsgBody) override;
-
-	virtual bool SendPrivateChat(const FUniqueNetId& UserId, const FUniqueNetId& RecipientId, const FString& MsgBody) override;
-
-	virtual bool IsChatAllowed(const FUniqueNetId& UserId, const FUniqueNetId& RecipientId) const override;
-
-	virtual void GetJoinedRooms(const FUniqueNetId& UserId, TArray<FChatRoomId>& OutRooms) override;
-
-	virtual TSharedPtr<FChatRoomInfo> GetRoomInfo(const FUniqueNetId& UserId, const FChatRoomId& RoomId) override;
-
-	virtual bool GetMembers(const FUniqueNetId& UserId, const FChatRoomId& RoomId, TArray< TSharedRef<FChatRoomMember> >& OutMembers) override { return false; }
-
-	virtual TSharedPtr<FChatRoomMember> GetMember(const FUniqueNetId& UserId, const FChatRoomId& RoomId, const FUniqueNetId& MemberId) override { return false; }
-
-	virtual bool GetLastMessages(const FUniqueNetId& UserId, const FChatRoomId& RoomId, int32 NumMessages, TArray< TSharedRef<FChatMessage> >& OutMessages) override;
-
-	virtual void DumpChatState() const override {}
-
-public:
-	void ConnectAttemptFinished(const FUniqueNetId& UserId, const FChatRoomId& RoomId, bool bSuccess, const FString& ErrorMessage);
-	bool ExitRoomWithReason(const FUniqueNetId& UserId, const FChatRoomId& RoomId, bool bIsClean, const FString& Reason);
-
-private:
-
-	bool IsDefaultChatRoom(const FChatRoomId& RoomId) const;
-	bool WillJoinAnonymously() const;
-	bool RemoveConnectionForRoom(const FChatRoomId& RoomId);
-
-	/**
-	* Connection to the default chat channel for the current Mixer session -
-	* that is, the channel owned by the current Mixer user.
-	*/
-	TSharedPtr<class FMixerChatConnection> DefaultChatConnection;
-
-	/** Connection to additional chat channels that we may want to interact with. */
-	TArray<TSharedRef<class FMixerChatConnection>> AdditionalChatConnections;
 };

--- a/Source/MixerInteractivity/Public/OnlineChatMixer.h
+++ b/Source/MixerInteractivity/Public/OnlineChatMixer.h
@@ -25,7 +25,7 @@ public:
 
 	}
 
-private:
+protected:
 	TSharedRef<const FUniqueNetId> FromUser;
 	FString FromUserName;
 	FString MessageText;
@@ -64,14 +64,19 @@ public:
 
 	virtual TSharedPtr<FChatRoomMember> GetMember(const FUniqueNetId& UserId, const FChatRoomId& RoomId, const FUniqueNetId& MemberId) override { return false; }
 
-	virtual bool GetLastMessages(const FUniqueNetId& UserId, const FChatRoomId& RoomId, int32 NumMessages, TArray< TSharedRef<FChatMessage> >& OutMessages) { return false; }
+	virtual bool GetLastMessages(const FUniqueNetId& UserId, const FChatRoomId& RoomId, int32 NumMessages, TArray< TSharedRef<FChatMessage> >& OutMessages) override;
 
 	virtual void DumpChatState() const override {}
+
+public:
+	void ConnectAttemptFinished(const FUniqueNetId& UserId, const FChatRoomId& RoomId, bool bSuccess, const FString& ErrorMessage);
+	bool ExitRoomWithReason(const FUniqueNetId& UserId, const FChatRoomId& RoomId, bool bIsClean, const FString& Reason);
 
 private:
 
 	bool IsDefaultChatRoom(const FChatRoomId& RoomId) const;
 	bool WillJoinAnonymously() const;
+	bool RemoveConnectionForRoom(const FChatRoomId& RoomId);
 
 	/**
 	* Connection to the default chat channel for the current Mixer session -

--- a/Source/MixerInteractivity/Public/OnlineChatMixer.h
+++ b/Source/MixerInteractivity/Public/OnlineChatMixer.h
@@ -1,8 +1,6 @@
 #pragma once
 
 #include "Interfaces/OnlineChatInterface.h"
-#include "Interfaces/IHttpRequest.h"
-#include "Interfaces/IHttpResponse.h"
 
 /**
 * Implementation of FChatMessage for messages received via Mixer.
@@ -11,9 +9,22 @@
 struct FChatMessageMixer : public FChatMessage
 {
 public:
-	virtual bool IsWhisper() = 0;
-	virtual bool IsAction() = 0;
-	virtual bool IsModerated() = 0;
+	virtual bool IsWhisper() const = 0;
+	virtual bool IsAction() const = 0;
+	virtual bool IsModerated() const = 0;
+};
+
+struct FChatPollMixer
+{
+public:
+	virtual ~FChatPollMixer() {}
+
+	virtual TSharedRef<const FChatRoomMember> GetAskingUser() const = 0;
+	virtual const FString& GetQuestion() const = 0;
+	virtual int32 GetNumAnswers() const = 0;
+	virtual const FString& GetAnswer(int32 Index) const = 0;
+	virtual int32 GetNumVotersForAnswer(int32 Index) const = 0;
+	virtual FDateTime GetEndTime() const = 0;
 };
 
 /**
@@ -36,13 +47,50 @@ DECLARE_MULTICAST_DELEGATE_ThreeParams(FOnChatRoomUserPurged, const FUniqueNetId
 typedef FOnChatRoomUserPurged::FDelegate FOnChatRoomUserPurgedDelegate;
 
 /**
+* Delegate used when a poll starts in a Mixer chat channel
+*
+* @param UserId user currently in the room
+* @param RoomId room that member is in
+* @param ChatPoll object representing the poll that is starting
+*/
+DECLARE_MULTICAST_DELEGATE_ThreeParams(FOnChatRoomPollStart, const FUniqueNetId& /*UserId*/, const FChatRoomId& /*RoomId*/, const TSharedRef<FChatPollMixer>& /*ChatPoll*/);
+typedef FOnChatRoomPollStart::FDelegate FOnChatRoomPollStartDelegate;
+
+/**
+* Delegate used when updated data is received for a poll in a Mixer chat channel
+*
+* @param UserId user currently in the room
+* @param RoomId room that member is in
+* @param ChatPoll object representing the poll that has been updated
+*/
+DECLARE_MULTICAST_DELEGATE_ThreeParams(FOnChatRoomPollUpdate, const FUniqueNetId& /*UserId*/, const FChatRoomId& /*RoomId*/, const TSharedRef<FChatPollMixer>& /*ChatPoll*/);
+typedef FOnChatRoomPollUpdate::FDelegate FOnChatRoomPollUpdateDelegate;
+
+/**
+* Delegate used when a poll ends in a Mixer chat channel
+*
+* @param UserId user currently in the room
+* @param RoomId room that member is in
+* @param ChatPoll object representing the poll that is ending
+*/
+DECLARE_MULTICAST_DELEGATE_ThreeParams(FOnChatRoomPollEnd, const FUniqueNetId& /*UserId*/, const FChatRoomId& /*RoomId*/, const TSharedRef<FChatPollMixer>& /*ChatPoll*/);
+typedef FOnChatRoomPollEnd::FDelegate FOnChatRoomPollEndDelegate;
+
+/**
 * Extension of IOnlineChat for Mixer.
 * Rooms map to Mixer channels and are identified by the username of their owner.
 */
 class IOnlineChatMixer : public IOnlineChat
 {
 public:
+	virtual bool StartPoll(const FUniqueNetId& UserId, const FChatRoomId& RoomId, const FString& Question, const TArray<FString>& Answers, FTimespan Duration) = 0;
+	virtual bool VoteInPoll(const FUniqueNetId& UserId, const FChatRoomId& RoomId, const FChatPollMixer& Poll, int32 AnswerIndex) = 0;
+
+
 	DEFINE_ONLINE_DELEGATE_TWO_PARAM(OnChatRoomMessagesCleared, const FUniqueNetId&, const FChatRoomId&);
 	DEFINE_ONLINE_DELEGATE_THREE_PARAM(OnChatRoomUserPurged, const FUniqueNetId&, const FChatRoomId&, const FUniqueNetId&);
+	DEFINE_ONLINE_DELEGATE_THREE_PARAM(OnChatRoomPollStart, const FUniqueNetId&, const FChatRoomId&, const TSharedRef<FChatPollMixer>&);
+	DEFINE_ONLINE_DELEGATE_THREE_PARAM(OnChatRoomPollUpdate, const FUniqueNetId&, const FChatRoomId&, const TSharedRef<FChatPollMixer>&);
+	DEFINE_ONLINE_DELEGATE_THREE_PARAM(OnChatRoomPollEnd, const FUniqueNetId&, const FChatRoomId&, const TSharedRef<FChatPollMixer>&);
 
 };

--- a/Source/MixerInteractivity/Public/OnlineChatMixer.h
+++ b/Source/MixerInteractivity/Public/OnlineChatMixer.h
@@ -1,0 +1,84 @@
+#pragma once
+
+#include "Interfaces/OnlineChatInterface.h"
+#include "Interfaces/IHttpRequest.h"
+#include "Interfaces/IHttpResponse.h"
+
+/**
+* Implementation of FChatMessage for messages received via Mixer.
+* See FChatMessage for interface method details.
+*/
+struct FChatMessageMixer : public FChatMessage
+{
+public:
+	virtual const TSharedRef<const FUniqueNetId>& GetUserId() const override { return FromUser; }
+	virtual const FString& GetNickname() const override { return FromUserName; }
+	virtual const FString& GetBody() const override { return MessageText; }
+	virtual const FDateTime& GetTimestamp() const override { return ReceivedAt; }
+
+	FChatMessageMixer(TSharedRef<const FUniqueNetId> InUser, const FString& InText)
+		: FromUser(InUser)
+		, FromUserName(InUser->ToString())
+		, ReceivedAt(FDateTime::Now())
+		, MessageText(InText)
+	{
+
+	}
+
+private:
+	TSharedRef<const FUniqueNetId> FromUser;
+	FString FromUserName;
+	FString MessageText;
+	FDateTime ReceivedAt;
+};
+
+/**
+* Implementation of IOnlineChat for Mixer.
+* Rooms map to Mixer channels and are identified by the username of their owner.
+* See IOnlineChat for interface method details.
+*/
+class FOnlineChatMixer : public IOnlineChat, public TSharedFromThis<FOnlineChatMixer>
+{
+public:
+	virtual bool CreateRoom(const FUniqueNetId& UserId, const FChatRoomId& RoomId, const FString& Nickname, const FChatRoomConfig& ChatRoomConfig) override { return false; }
+
+	virtual bool ConfigureRoom(const FUniqueNetId& UserId, const FChatRoomId& RoomId, const FChatRoomConfig& ChatRoomConfig) override { return false; }
+
+	virtual bool JoinPublicRoom(const FUniqueNetId& UserId, const FChatRoomId& RoomId, const FString& Nickname, const FChatRoomConfig& ChatRoomConfig) override;
+
+	virtual bool JoinPrivateRoom(const FUniqueNetId& UserId, const FChatRoomId& RoomId, const FString& Nickname, const FChatRoomConfig& ChatRoomConfig) override { return false; }
+
+	virtual bool ExitRoom(const FUniqueNetId& UserId, const FChatRoomId& RoomId) override { return false; }
+
+	virtual bool SendRoomChat(const FUniqueNetId& UserId, const FChatRoomId& RoomId, const FString& MsgBody) override;
+
+	virtual bool SendPrivateChat(const FUniqueNetId& UserId, const FUniqueNetId& RecipientId, const FString& MsgBody) override;
+
+	virtual bool IsChatAllowed(const FUniqueNetId& UserId, const FUniqueNetId& RecipientId) const override;
+
+	virtual void GetJoinedRooms(const FUniqueNetId& UserId, TArray<FChatRoomId>& OutRooms) override;
+
+	virtual TSharedPtr<FChatRoomInfo> GetRoomInfo(const FUniqueNetId& UserId, const FChatRoomId& RoomId) override;
+
+	virtual bool GetMembers(const FUniqueNetId& UserId, const FChatRoomId& RoomId, TArray< TSharedRef<FChatRoomMember> >& OutMembers) override { return false; }
+
+	virtual TSharedPtr<FChatRoomMember> GetMember(const FUniqueNetId& UserId, const FChatRoomId& RoomId, const FUniqueNetId& MemberId) override { return false; }
+
+	virtual bool GetLastMessages(const FUniqueNetId& UserId, const FChatRoomId& RoomId, int32 NumMessages, TArray< TSharedRef<FChatMessage> >& OutMessages) { return false; }
+
+	virtual void DumpChatState() const override {}
+
+private:
+
+	bool IsDefaultChatRoom(const FChatRoomId& RoomId) const;
+	bool WillJoinAnonymously() const;
+
+	/**
+	* Connection to the default chat channel for the current Mixer session -
+	* that is, the channel owned by the current Mixer user.
+	*/
+	TSharedPtr<class FMixerChatConnection> DefaultChatConnection;
+
+	/** Connection to additional chat channels that we may want to interact with. */
+	TArray<TSharedRef<class FMixerChatConnection>> AdditionalChatConnections;
+};

--- a/Source/MixerInteractivity/Public/OnlineChatMixer.h
+++ b/Source/MixerInteractivity/Public/OnlineChatMixer.h
@@ -11,25 +11,9 @@
 struct FChatMessageMixer : public FChatMessage
 {
 public:
-	virtual const TSharedRef<const FUniqueNetId>& GetUserId() const override { return FromUser; }
-	virtual const FString& GetNickname() const override { return FromUserName; }
-	virtual const FString& GetBody() const override { return MessageText; }
-	virtual const FDateTime& GetTimestamp() const override { return ReceivedAt; }
-
-	FChatMessageMixer(TSharedRef<const FUniqueNetId> InUser, const FString& InText)
-		: FromUser(InUser)
-		, FromUserName(InUser->ToString())
-		, ReceivedAt(FDateTime::Now())
-		, MessageText(InText)
-	{
-
-	}
-
-protected:
-	TSharedRef<const FUniqueNetId> FromUser;
-	FString FromUserName;
-	FString MessageText;
-	FDateTime ReceivedAt;
+	virtual bool IsWhisper() = 0;
+	virtual bool IsAction() = 0;
+	virtual bool IsModerated() = 0;
 };
 
 /**

--- a/Source/MixerInteractivityEditor/Private/MixerInteractivityEditorModule.cpp
+++ b/Source/MixerInteractivityEditor/Private/MixerInteractivityEditorModule.cpp
@@ -100,12 +100,11 @@ bool FMixerInteractivityEditorModule::RequestAvailableInteractiveGames(FOnMixerI
 	TSharedPtr<const FMixerLocalUser> MixerUser = MixerRuntimeModule.GetCurrentUser();
 	check(MixerUser.IsValid());
 	FString GamesListUrl = FString::Printf(TEXT("https://mixer.com/api/v1/interactive/games/owned?user=%d"), MixerUser->Id);
-	FString AuthZHeaderValue = FString::Printf(TEXT("Bearer %s"), *UserSettings->AccessToken);
 
 	TSharedRef<IHttpRequest> GamesRequest = FHttpModule::Get().CreateRequest();
 	GamesRequest->SetVerb(TEXT("GET"));
 	GamesRequest->SetURL(GamesListUrl);
-	GamesRequest->SetHeader(TEXT("Authorization"), AuthZHeaderValue);
+	GamesRequest->SetHeader(TEXT("Authorization"), UserSettings->GetAuthZHeaderValue());
 	GamesRequest->OnProcessRequestComplete().BindLambda(
 		[OnFinished](FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bSucceeded)
 	{


### PR DESCRIPTION
Setting up the PR for visibility.  Will continue to iterate and address known gaps listed below:
- [x] Currently Win32 only.
- [x] Treatment of net ids could use some work.  We should probably have a proper derived type of FUniqueNetId for Mixer vs the current just-in-time creation of ids based on username.
- [ ] Should add optional support for richer message format to properly express tags, emotes, etc.
- [x] Needs support for additional chat interactions, both those supported by the standard UE interface (e.g. message history, channel members) and Mixer-specific extensions (e.g. polls, moderation).

#4
