### PR TITLE
Isolate interactive-cpp

### DIFF
--- a/Source/MixerInteractivity/MixerInteractivity.build.cs
+++ b/Source/MixerInteractivity/MixerInteractivity.build.cs
@@ -64,6 +64,5 @@ public class MixerInteractivity : ModuleRules
 
 		bEnableExceptions = true;
 		PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
-		bFasterWithoutUnity = true;
 	}
 }

--- a/Source/MixerInteractivity/MixerInteractivity.build.cs
+++ b/Source/MixerInteractivity/MixerInteractivity.build.cs
@@ -33,6 +33,7 @@ public class MixerInteractivity : ModuleRules
 		{
 			Definitions.Add("PLATFORM_SUPPORTS_MIXER_OAUTH=1");
 			Definitions.Add("MIXER_BACKEND_INTERACTIVE_CPP=1");
+			Definitions.Add("MIXER_BACKEND_NULL=0");
 			PrivateDependencyModuleNames.AddRange(
 				new string[]
 				{
@@ -49,6 +50,7 @@ public class MixerInteractivity : ModuleRules
 		{
 			Definitions.Add("PLATFORM_SUPPORTS_MIXER_OAUTH=0");
 			Definitions.Add("MIXER_BACKEND_INTERACTIVE_CPP=1");
+			Definitions.Add("MIXER_BACKEND_NULL=0");
 
 			PublicAdditionalLibraries.Add("Interactivity.Xbox.Cpp.lib");
 			PublicAdditionalLibraries.Add("casablanca140.xbox.lib");
@@ -57,6 +59,7 @@ public class MixerInteractivity : ModuleRules
 		{
 			Definitions.Add("PLATFORM_SUPPORTS_MIXER_OAUTH=0");
 			Definitions.Add("MIXER_BACKEND_NULL=1");
+			Definitions.Add("MIXER_BACKEND_INTERACTIVE_CPP=0");
 		}
 
 		bEnableExceptions = true;

--- a/Source/MixerInteractivity/MixerInteractivity.build.cs
+++ b/Source/MixerInteractivity/MixerInteractivity.build.cs
@@ -32,6 +32,7 @@ public class MixerInteractivity : ModuleRules
 		if (Target.Platform == UnrealTargetPlatform.Win64 || Target.Platform == UnrealTargetPlatform.Win32)
 		{
 			Definitions.Add("PLATFORM_SUPPORTS_MIXER_OAUTH=1");
+			Definitions.Add("MIXER_BACKEND_INTERACTIVE_CPP=1");
 			PrivateDependencyModuleNames.AddRange(
 				new string[]
 				{
@@ -47,6 +48,7 @@ public class MixerInteractivity : ModuleRules
 		else if (Target.Platform == UnrealTargetPlatform.XboxOne)
 		{
 			Definitions.Add("PLATFORM_SUPPORTS_MIXER_OAUTH=0");
+			Definitions.Add("MIXER_BACKEND_INTERACTIVE_CPP=1");
 
 			PublicAdditionalLibraries.Add("Interactivity.Xbox.Cpp.lib");
 			PublicAdditionalLibraries.Add("casablanca140.xbox.lib");
@@ -54,9 +56,11 @@ public class MixerInteractivity : ModuleRules
 		else
 		{
 			Definitions.Add("PLATFORM_SUPPORTS_MIXER_OAUTH=0");
+			Definitions.Add("MIXER_BACKEND_NULL=1");
 		}
 
 		bEnableExceptions = true;
 		PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
+		bFasterWithoutUnity = true;
 	}
 }

--- a/Source/MixerInteractivity/Private/MixerInteractivityModulePrivate.cpp
+++ b/Source/MixerInteractivity/Private/MixerInteractivityModulePrivate.cpp
@@ -79,7 +79,7 @@ bool FMixerInteractivityModule::LoginSilently(TSharedPtr<const FUniqueNetId> Use
 		}
 		return nullptr;
 	});
-#else
+#elif PLATFORM_SUPPORTS_MIXER_OAUTH
 	if (UserAuthState == EMixerLoginState::Logged_In)
 	{
 		check(NeedsClientLibraryActive());
@@ -127,6 +127,9 @@ bool FMixerInteractivityModule::LoginSilently(TSharedPtr<const FUniqueNetId> Use
 	{
 		return false;
 	}
+#else
+	UE_LOG(LogMixerInteractivity, Warning, TEXT("There is no supported user login flow for this platform."));
+	return false;
 #endif
 
 	NetId = UserId;
@@ -288,25 +291,6 @@ EMixerLoginState FMixerInteractivityModule::GetLoginState()
 		if (NeedsClientLibraryActive())
 		{
 			return InteractiveConnectionAuthState;
-
-			//switch (ClientLibraryState)
-			//{
-			//case Microsoft::mixer::not_initialized:
-			//	return EMixerLoginState::Not_Logged_In;
-
-			//case Microsoft::mixer::initializing:
-			//	return EMixerLoginState::Logging_In;
-
-			//case Microsoft::mixer::interactivity_disabled:
-			//case Microsoft::mixer::interactivity_enabled:
-			//case Microsoft::mixer::interactivity_pending:
-			//	return EMixerLoginState::Logged_In;
-
-			//default:
-			//	// Internal error in Mixer client library state management
-			//	check(false);
-			//	return EMixerLoginState::Not_Logged_In;
-			//}
 		}
 		else
 		{
@@ -534,29 +518,6 @@ void FMixerInteractivityModule::OnUserRequestComplete(FHttpRequestPtr HttpReques
 				check(false);
 				break;
 			}
-
-			//switch (ClientLibraryState)
-			//{
-			//case Microsoft::mixer::not_initialized:
-			//	if (!Microsoft::mixer::interactivity_manager::get_singleton_instance()->initialize(*FString::FromInt(Settings->GameVersionId), false, *Settings->ShareCode))
-			//	{
-			//		LoginAttemptFinished(false);
-			//	}
-			//	else
-			//	{
-			//		// Set this immediately to avoid a temporary pop to Not_Logged_In
-			//		ClientLibraryState = Microsoft::mixer::initializing;
-			//	}
-			//	break;
-
-			//case Microsoft::mixer::initializing:
-			//	// Should naturally progress and we'll handle it in Tick
-			//	break;
-
-			//default:
-			//	// We're already logged in
-			//	LoginAttemptFinished(true);
-			//}
 		}
 		else
 		{

--- a/Source/MixerInteractivity/Private/MixerInteractivityModulePrivate.cpp
+++ b/Source/MixerInteractivity/Private/MixerInteractivityModulePrivate.cpp
@@ -37,6 +37,10 @@
 #include "SMixerLoginPane.h"
 #endif
 
+#if PLATFORM_XBOXONE
+#include "XboxOneInputInterface.h"
+#endif
+
 DEFINE_LOG_CATEGORY(LogMixerInteractivity);
 
 void FMixerInteractivityModule::StartupModule()
@@ -48,18 +52,16 @@ void FMixerInteractivityModule::StartupModule()
 	ChatInterface = MakeShared<FOnlineChatMixer>();
 
 #if PLATFORM_XBOXONE
-	UserRemovedToken = (Windows::Xbox::System::User::UserRemoved += ref new Windows::Foundation::EventHandler<Windows::Xbox::System::UserRemovedEventArgs^>(
-		[this](Platform::Object^, Windows::Xbox::System::UserRemovedEventArgs^ Args)
-	{
-		OnXboxUserRemoved(Args->User);
-	}));
+	check(FSlateApplication::IsInitialized());
+	static_cast<FXboxOneInputInterface*>(FSlateApplication::Get().GetInputInterface())->OnUserRemovedDelegates.AddRaw(this, &FMixerInteractivityModule::OnXboxUserRemoved);
 #endif
 }
 
 void FMixerInteractivityModule::ShutdownModule()
 {
 #if PLATFORM_XBOXONE
-	Windows::Xbox::System::User::UserRemoved -= UserRemovedToken;
+	check(FSlateApplication::IsInitialized());
+	static_cast<FXboxOneInputInterface*>(FSlateApplication::Get().GetInputInterface())->OnUserRemovedDelegates.RemoveAll(this);
 #endif
 }
 

--- a/Source/MixerInteractivity/Private/MixerInteractivityModulePrivate.h
+++ b/Source/MixerInteractivity/Private/MixerInteractivityModulePrivate.h
@@ -78,6 +78,7 @@ class FMixerInteractivityModule :
 {
 public:
 	virtual void StartupModule() override;
+	virtual void ShutdownModule() override;
 
 public:
 	virtual bool LoginSilently(TSharedPtr<const FUniqueNetId> UserId);
@@ -141,7 +142,9 @@ private:
 #if PLATFORM_XBOXONE
 	TFuture<Windows::Xbox::System::User^> XboxUserOperation;
 	Windows::Foundation::IAsyncOperation<Windows::Xbox::System::GetTokenAndSignatureResult^>^ GetXTokenOperation;
+	Windows::Foundation::EventRegistrationToken UserRemovedToken;
 	void TickXboxLogin();
+	void OnXboxUserRemoved(Windows::Xbox::System::User^ RemovedUser);
 #endif
 
 	TSharedPtr<SWindow> LoginWindow;

--- a/Source/MixerInteractivity/Private/MixerInteractivityModulePrivate.h
+++ b/Source/MixerInteractivity/Private/MixerInteractivityModulePrivate.h
@@ -30,17 +30,6 @@
 #include "CoreOnline.h"
 #include <memory>
 
-namespace Microsoft
-{
-	namespace mixer
-	{
-		class interactive_button_control;
-		class interactive_joystick_control;
-		class interactive_participant;
-		enum interactivity_state : int;
-	}
-}
-
 struct FMixerChannelJsonSerializable : public FMixerChannel, public FJsonSerializable
 {
 public:
@@ -77,18 +66,6 @@ public:
 	}
 };
 
-struct FMixerRemoteUserCached : public FMixerRemoteUser
-{
-public:
-	FMixerRemoteUserCached(std::shared_ptr<Microsoft::mixer::interactive_participant> InParticipant);
-
-	void UpdateFromSourceParticipant();
-
-	std::shared_ptr<Microsoft::mixer::interactive_participant> GetSourceParticipant() { return SourceParticipant; }
-private:
-	std::shared_ptr<Microsoft::mixer::interactive_participant> SourceParticipant;
-};
-
 class SWindow;
 class SOverlay;
 class IWebBrowserWindow;
@@ -109,30 +86,12 @@ public:
 	virtual bool Logout();
 	virtual EMixerLoginState GetLoginState();
 
-	virtual void StartInteractivity();
-	virtual void StopInteractivity();
 	virtual EMixerInteractivityState GetInteractivityState();
-
-	virtual void SetCurrentScene(FName Scene, FName GroupName = NAME_None);
-	virtual FName GetCurrentScene(FName GroupName = NAME_None);
-	virtual void TriggerButtonCooldown(FName Button, FTimespan CooldownTime);
-	virtual bool GetButtonDescription(FName Button, FMixerButtonDescription& OutDesc);
-	virtual bool GetButtonState(FName Button, FMixerButtonState& OutState);
-	virtual bool GetButtonState(FName Button, uint32 ParticipantId, FMixerButtonState& OutState);
-	virtual bool GetStickDescription(FName Stick, FMixerStickDescription& OutDesc);
-	virtual bool GetStickState(FName Stick, FMixerStickState& OutState);
-	virtual bool GetStickState(FName Stick, uint32 ParticipantId, FMixerStickState& OutState);
 
 	virtual TSharedPtr<const FMixerLocalUser> GetCurrentUser()
 	{
 		return CurrentUser;
 	}
-	virtual TSharedPtr<const FMixerRemoteUser> GetParticipant(uint32 ParticipantId);
-
-	virtual bool CreateGroup(FName GroupName, FName InitialScene = NAME_None);
-	virtual bool GetParticipantsInGroup(FName GroupName, TArray<TSharedPtr<const FMixerRemoteUser>>& OutParticipants);
-	virtual bool MoveParticipantToGroup(FName GroupName, uint32 ParticipantId);
-	virtual void CaptureSparkTransaction(const FString& TransactionId);
 
 	virtual TSharedPtr<class IOnlineChat> GetChatInterface();
 	virtual TSharedPtr<class IOnlineChatMixer> GetExtendedChatInterface();
@@ -145,8 +104,23 @@ public:
 	virtual FOnBroadcastingStateChanged& OnBroadcastingStateChanged()		{ return BroadcastingStateChanged; }
 
 public:
-
 	virtual bool Tick(float DeltaTime);
+
+protected:
+	virtual bool StartInteractiveConnection() = 0;
+
+protected:
+	void LoginAttemptFinished(bool Success);
+
+	EMixerLoginState GetUserAuthState() const							{ return UserAuthState; }
+	EMixerLoginState GetInteractiveConntectionAuthState() const			{ return InteractiveConnectionAuthState; }
+	void SetInteractiveConnectionAuthState(EMixerLoginState InState)	{ InteractiveConnectionAuthState = InState; }
+	EMixerInteractivityState GetInteractivityState() const				{ return InteractivityState; }
+	void SetInteractivityState(EMixerInteractivityState InState)		{ InteractivityState = InState; InteractivityStateChanged.Broadcast(InState); }
+
+#if PLATFORM_XBOXONE
+	Windows::Xbox::System::User^ GetXboxUser()							{ return XboxUserOperation.Get(); }
+#endif
 
 private:
 	bool LoginWithAuthCodeInternal(const FString& AuthCode, TSharedPtr<const FUniqueNetId> UserId);
@@ -162,20 +136,13 @@ private:
 	bool NeedsClientLibraryActive();
 	void InitDesignTimeGroups();
 
-	std::shared_ptr<Microsoft::mixer::interactive_button_control> FindButton(FName Name);
-	std::shared_ptr<Microsoft::mixer::interactive_joystick_control> FindStick(FName Name);
-	TSharedPtr<FMixerRemoteUserCached> CreateOrUpdateCachedParticipant(std::shared_ptr<Microsoft::mixer::interactive_participant> Participant);
-
-	void TickParticipantCacheMaintenance();
-	void TickClientLibrary();
 	void TickLocalUserMaintenance();
 
-	void LoginAttemptFinished(bool Success);
 
 private:
 
 #if PLATFORM_XBOXONE
-	TFuture<Windows::Xbox::System::User^> PlatformUser;
+	TFuture<Windows::Xbox::System::User^> XboxUserOperation;
 	Windows::Foundation::IAsyncOperation<Windows::Xbox::System::GetTokenAndSignatureResult^>^ GetXTokenOperation;
 	void TickXboxLogin();
 #endif
@@ -186,10 +153,8 @@ private:
 	TSharedPtr<const FUniqueNetId> NetId;
 	TSharedPtr<FMixerLocalUserJsonSerializable> CurrentUser;
 
-	TMap<uint32, TSharedPtr<FMixerRemoteUserCached>> RemoteParticipantCache;
-
 	EMixerLoginState UserAuthState;
-	Microsoft::mixer::interactivity_state ClientLibraryState;
+	EMixerLoginState InteractiveConnectionAuthState;
 	EMixerInteractivityState InteractivityState;
 
 	FOnLoginStateChanged LoginStateChanged;

--- a/Source/MixerInteractivity/Private/MixerInteractivityModulePrivate.h
+++ b/Source/MixerInteractivity/Private/MixerInteractivityModulePrivate.h
@@ -142,7 +142,6 @@ private:
 #if PLATFORM_XBOXONE
 	TFuture<Windows::Xbox::System::User^> XboxUserOperation;
 	Windows::Foundation::IAsyncOperation<Windows::Xbox::System::GetTokenAndSignatureResult^>^ GetXTokenOperation;
-	Windows::Foundation::EventRegistrationToken UserRemovedToken;
 	void TickXboxLogin();
 	void OnXboxUserRemoved(Windows::Xbox::System::User^ RemovedUser);
 #endif

--- a/Source/MixerInteractivity/Private/MixerInteractivityModulePrivate.h
+++ b/Source/MixerInteractivity/Private/MixerInteractivityModulePrivate.h
@@ -88,10 +88,7 @@ public:
 
 	virtual EMixerInteractivityState GetInteractivityState();
 
-	virtual TSharedPtr<const FMixerLocalUser> GetCurrentUser()
-	{
-		return CurrentUser;
-	}
+	virtual TSharedPtr<const FMixerLocalUser> GetCurrentUser()				{ return CurrentUser; }
 
 	virtual TSharedPtr<class IOnlineChat> GetChatInterface();
 	virtual TSharedPtr<class IOnlineChatMixer> GetExtendedChatInterface();
@@ -108,21 +105,21 @@ public:
 
 protected:
 	virtual bool StartInteractiveConnection() = 0;
-
-protected:
-	void LoginAttemptFinished(bool Success);
-
-	EMixerLoginState GetUserAuthState() const							{ return UserAuthState; }
-	EMixerLoginState GetInteractiveConntectionAuthState() const			{ return InteractiveConnectionAuthState; }
-	void SetInteractiveConnectionAuthState(EMixerLoginState InState)	{ InteractiveConnectionAuthState = InState; }
+	EMixerLoginState GetInteractiveConnectionAuthState() const			{ return InteractiveConnectionAuthState; }
+	void SetInteractiveConnectionAuthState(EMixerLoginState InState);
 	EMixerInteractivityState GetInteractivityState() const				{ return InteractivityState; }
 	void SetInteractivityState(EMixerInteractivityState InState)		{ InteractivityState = InState; InteractivityStateChanged.Broadcast(InState); }
-
 #if PLATFORM_XBOXONE
 	Windows::Xbox::System::User^ GetXboxUser()							{ return XboxUserOperation.Get(); }
 #endif
 
 private:
+	EMixerLoginState GetUserAuthState() const { return UserAuthState; }
+	void SetUserAuthState(EMixerLoginState InState);
+	void HandleLoginStateChange(EMixerLoginState OldState, EMixerLoginState NewState);
+
+	bool LoginSilentlyInternal(TSharedPtr<const FUniqueNetId> UserId);
+	void LoginWithUIInternal(TSharedPtr<const FUniqueNetId> UserId);
 	bool LoginWithAuthCodeInternal(const FString& AuthCode, TSharedPtr<const FUniqueNetId> UserId);
 
 	void OnTokenRequestComplete(FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bSucceeded);
@@ -167,5 +164,4 @@ private:
 	TSharedPtr<class FOnlineChatMixer> ChatInterface;
 
 	bool RetryLoginWithUI;
-	bool HasCreatedGroups;
 };

--- a/Source/MixerInteractivity/Private/MixerInteractivityModule_InteractiveCpp.cpp
+++ b/Source/MixerInteractivity/Private/MixerInteractivityModule_InteractiveCpp.cpp
@@ -8,6 +8,9 @@
 //
 //*********************************************************
 #include "MixerInteractivityModule_InteractiveCpp.h"
+
+#if MIXER_BACKEND_INTERACTIVE_CPP
+
 #include "MixerInteractivityLog.h"
 #include "MixerInteractivitySettings.h"
 #include "MixerInteractivityUserSettings.h"
@@ -625,3 +628,8 @@ void FMixerRemoteUserCached::UpdateFromSourceParticipant()
 	std::shared_ptr<Microsoft::mixer::interactive_group> GroupInternal = SourceParticipant->group();
 	Group = GroupInternal ? FName(GroupInternal->group_id().c_str()) : NAME_DefaultMixerParticipantGroup;
 }
+
+#endif // MIXER_BACKEND_INTERACTIVE_CPP
+
+// Suppress linker warning "warning LNK4221: no public symbols found; archive member will be inaccessible"
+int32 MixerInteractiveCppLinkerHelper;

--- a/Source/MixerInteractivity/Private/MixerInteractivityModule_InteractiveCpp.cpp
+++ b/Source/MixerInteractivity/Private/MixerInteractivityModule_InteractiveCpp.cpp
@@ -1,0 +1,627 @@
+//*********************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+// THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
+// ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY
+// IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR
+// PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
+//
+//*********************************************************
+#include "MixerInteractivityModule_InteractiveCpp.h"
+#include "MixerInteractivityLog.h"
+#include "MixerInteractivitySettings.h"
+#include "MixerInteractivityUserSettings.h"
+#include "MixerInteractivityTypes.h"
+#include "MixerInteractivityBlueprintLibrary.h"
+
+#if PLATFORM_WINDOWS
+#include "PreWindowsApi.h"
+#define TV_API 0
+#define CPPREST_FORCE_PPLX 0
+#define XBOX_UWP 0
+#elif PLATFORM_XBOXONE
+#include "XboxOneAllowPlatformTypes.h"
+#define TV_API 1
+#endif
+#define _TURN_OFF_PLATFORM_STRING
+#define _NO_MIXERIMP
+#pragma warning(push)
+#pragma warning(disable:4628)
+#pragma warning(disable:4596)
+#pragma pack(push)
+#pragma pack(8)
+#include <interactivity_types.h>
+#include <interactivity.h>
+#pragma pack(pop)
+#pragma warning(pop)
+#if PLATFORM_WINDOWS
+#include "PostWindowsApi.h"
+#elif PLATFORM_XBOXONE
+#include "XboxOneHidePlatformTypes.h"
+#endif
+
+IMPLEMENT_MODULE(FMixerInteractivityModule_InteractiveCpp, MixerInteractivity);
+
+bool FMixerInteractivityModule_InteractiveCpp::StartInteractiveConnection()
+{
+#if PLATFORM_XBOXONE
+	Windows::Xbox::System::User^ ResolvedUser = GetXboxUser();
+	// User should have been resolved by the time we get here.
+	check(ResolvedUser != nullptr);
+	Microsoft::mixer::interactivity_manager::get_singleton_instance()->set_local_user(ResolvedUser);
+#elif PLATFORM_SUPPORTS_MIXER_OAUTH
+	const UMixerInteractivityUserSettings* UserSettings = GetDefault<UMixerInteractivityUserSettings>();
+	Microsoft::mixer::interactivity_manager::get_singleton_instance()->set_oauth_token(*UserSettings->AccessToken);
+#else
+	UE_LOG(LogMixerInteractivity, Fatal, TEXT("interactive-cpp does not support this platform."));
+	return false;
+#endif
+	const UMixerInteractivitySettings* Settings = GetDefault<UMixerInteractivitySettings>();
+	if (!Microsoft::mixer::interactivity_manager::get_singleton_instance()->initialize(*FString::FromInt(Settings->GameVersionId), false, *Settings->ShareCode))
+	{
+		UE_LOG(LogMixerInteractivity, Error, TEXT("Failed to initialize interactive-cpp"));
+		SetInteractiveConnectionAuthState(EMixerLoginState::Not_Logged_In);
+		return false;
+	}
+
+	SetInteractiveConnectionAuthState(EMixerLoginState::Logging_In);
+	return true;
+}
+
+bool FMixerInteractivityModule_InteractiveCpp::Tick(float DeltaTime)
+{
+	FMixerInteractivityModule::Tick(DeltaTime);
+
+	using namespace Microsoft::mixer;
+
+	std::vector<interactive_event> EventsThisFrame = interactivity_manager::get_singleton_instance()->do_work();
+	for (auto& MixerEvent : EventsThisFrame)
+	{
+		switch (MixerEvent.event_type())
+		{
+		case interactive_event_type::error:
+			// Errors that impact our login state are accompanied by an interactivity_state_changed event, so
+			// dealing with them here is just double counting.  Stick to outputting the message.
+			UE_LOG(LogMixerInteractivity, Warning, TEXT("%s"), MixerEvent.err_message().c_str());
+			break;
+
+		case interactive_event_type::interactivity_state_changed:
+		{
+			auto StateChangeArgs = std::static_pointer_cast<interactivity_state_change_event_args>(MixerEvent.event_args());
+			EMixerLoginState PreviousLoginState = GetLoginState();
+			ClientLibraryState = StateChangeArgs->new_state();
+			switch (StateChangeArgs->new_state())
+			{
+			case interactivity_state::not_initialized:
+				SetInteractiveConnectionAuthState(EMixerLoginState::Not_Logged_In);
+				SetInteractivityState(EMixerInteractivityState::Not_Interactive);
+				switch (PreviousLoginState)
+				{
+				case EMixerLoginState::Logging_In:
+					// On Xbox a pop to not_initialized is expected as a result of calling set_local_user when there
+					// was already a previous user.  In any case on all platforms we can safely postpone dealing with
+					// the client library state until user auth is finished.
+					if (GetUserAuthState() != EMixerLoginState::Logging_In)
+					{
+						LoginAttemptFinished(false);
+					}
+					break;
+
+				case EMixerLoginState::Logged_In:
+					// This will occur when stopping PIE.  It's annoying to have to login
+					// again to edit Mixer settings, so don't trigger logout here.
+					if (!GIsEditor)
+					{
+						Logout();
+					}
+					break;
+
+				default:
+					break;
+				}
+				break;
+
+			case interactivity_state::initializing:
+				SetInteractiveConnectionAuthState(EMixerLoginState::Logging_In);
+				SetInteractivityState(EMixerInteractivityState::Not_Interactive);
+				// Ensure the default group has a non-null representation
+				CreateGroup(NAME_DefaultMixerParticipantGroup);
+				break;
+
+			case interactivity_state::interactivity_pending:
+				SetInteractiveConnectionAuthState(EMixerLoginState::Logged_In);
+				if (PreviousLoginState == EMixerLoginState::Logging_In)
+				{
+					LoginAttemptFinished(true);
+				}
+				break;
+
+			case interactivity_state::interactivity_disabled:
+				SetInteractiveConnectionAuthState(EMixerLoginState::Logged_In);
+				SetInteractivityState(EMixerInteractivityState::Not_Interactive);
+				if (PreviousLoginState == EMixerLoginState::Logging_In)
+				{
+					LoginAttemptFinished(true);
+				}
+				break;
+
+			case interactivity_state::interactivity_enabled:
+				SetInteractiveConnectionAuthState(EMixerLoginState::Logged_In);
+				SetInteractivityState(EMixerInteractivityState::Interactive);
+				if (PreviousLoginState == EMixerLoginState::Logging_In)
+				{
+					LoginAttemptFinished(true);
+				}
+				break;
+			}
+		}
+		break;
+
+		case interactive_event_type::participant_state_changed:
+		{
+			auto ParticipantEventArgs = std::static_pointer_cast<interactive_participant_state_change_event_args>(MixerEvent.event_args());
+			TSharedPtr<const FMixerRemoteUser> RemoteParticipant = CreateOrUpdateCachedParticipant(ParticipantEventArgs->participant());
+			switch (ParticipantEventArgs->state())
+			{
+			case interactive_participant_state::joined:
+				OnParticipantStateChanged().Broadcast(RemoteParticipant, EMixerInteractivityParticipantState::Joined);
+				break;
+
+			case interactive_participant_state::left:
+				OnParticipantStateChanged().Broadcast(RemoteParticipant, EMixerInteractivityParticipantState::Left);
+				break;
+
+			case interactive_participant_state::input_disabled:
+				OnParticipantStateChanged().Broadcast(RemoteParticipant, EMixerInteractivityParticipantState::Input_Disabled);
+				break;
+
+			default:
+				break;
+			}
+		}
+		break;
+
+		case interactive_event_type::button:
+		{
+			auto OriginalButtonArgs = std::static_pointer_cast<interactive_button_event_args>(MixerEvent.event_args());
+			TSharedPtr<const FMixerRemoteUser> RemoteParticipant = CreateOrUpdateCachedParticipant(OriginalButtonArgs->participant());
+			FMixerButtonEventDetails Details;
+			Details.Pressed = OriginalButtonArgs->is_pressed();
+			Details.TransactionId = OriginalButtonArgs->transaction_id().c_str();
+			Details.SparkCost = OriginalButtonArgs->cost();
+			OnButtonEvent().Broadcast(FName(OriginalButtonArgs->control_id().c_str()), RemoteParticipant, Details);
+		}
+		break;
+
+		case interactive_event_type::joystick:
+		{
+			auto OriginalStickArgs = std::static_pointer_cast<interactive_joystick_event_args>(MixerEvent.event_args());
+			TSharedPtr<const FMixerRemoteUser> RemoteParticipant = CreateOrUpdateCachedParticipant(OriginalStickArgs->participant());
+			OnStickEvent().Broadcast(FName(OriginalStickArgs->control_id().c_str()), RemoteParticipant, FVector2D(OriginalStickArgs->x(), OriginalStickArgs->y()));
+			break;
+		}
+
+		default:
+			break;
+		}
+	}
+
+	TickParticipantCacheMaintenance();
+
+	return true;
+}
+
+
+void FMixerInteractivityModule_InteractiveCpp::StartInteractivity()
+{
+	switch (Microsoft::mixer::interactivity_manager::get_singleton_instance()->interactivity_state())
+	{
+	case Microsoft::mixer::interactivity_disabled:
+		check(GetInteractivityState() == EMixerInteractivityState::Not_Interactive || GetInteractivityState() == EMixerInteractivityState::Interactivity_Stopping);
+		Microsoft::mixer::interactivity_manager::get_singleton_instance()->start_interactive();
+		SetInteractivityState(EMixerInteractivityState::Interactivity_Starting);
+		break;
+
+	case Microsoft::mixer::interactivity_enabled:
+	case Microsoft::mixer::interactivity_pending:
+		check(GetInteractivityState() == EMixerInteractivityState::Interactivity_Starting || GetInteractivityState() == EMixerInteractivityState::Interactive);
+		// No-op, but not a problem
+		break;
+
+	case Microsoft::mixer::not_initialized:
+	case Microsoft::mixer::initializing:
+		check(GetInteractivityState() == EMixerInteractivityState::Not_Interactive || GetInteractivityState() == EMixerInteractivityState::Interactivity_Stopping);
+		// Caller should wait!
+		// @TODO: tell them so.
+		break;
+
+	default:
+		// Internal error in state management
+		check(false);
+		break;
+	}
+}
+
+void FMixerInteractivityModule_InteractiveCpp::StopInteractivity()
+{
+	switch (Microsoft::mixer::interactivity_manager::get_singleton_instance()->interactivity_state())
+	{
+	case Microsoft::mixer::interactivity_enabled:
+	case Microsoft::mixer::interactivity_pending:
+		check(GetInteractivityState() == EMixerInteractivityState::Interactivity_Starting ||
+			GetInteractivityState() == EMixerInteractivityState::Interactivity_Stopping ||
+			GetInteractivityState() == EMixerInteractivityState::Interactive);
+		Microsoft::mixer::interactivity_manager::get_singleton_instance()->stop_interactive();
+		SetInteractivityState(EMixerInteractivityState::Interactivity_Stopping);
+		break;
+
+	case Microsoft::mixer::interactivity_disabled:
+		check(GetInteractivityState() == EMixerInteractivityState::Not_Interactive || GetInteractivityState() == EMixerInteractivityState::Interactivity_Stopping);
+		// No-op, but not a problem
+		break;
+
+	case Microsoft::mixer::not_initialized:
+	case Microsoft::mixer::initializing:
+		check(GetInteractivityState() == EMixerInteractivityState::Not_Interactive || GetInteractivityState() == EMixerInteractivityState::Interactivity_Stopping);
+		// Caller should wait!
+		// @TODO: tell them so.
+		break;
+
+	default:
+		// Internal error in state management
+		check(false);
+		break;
+	}
+}
+
+void FMixerInteractivityModule_InteractiveCpp::SetCurrentScene(FName Scene, FName GroupName)
+{
+	using namespace Microsoft::mixer;
+
+	if (GetInteractivityState() == EMixerInteractivityState::Interactive)
+	{
+		std::shared_ptr<interactive_group> Group = GroupName == NAME_None ? interactivity_manager::get_singleton_instance()->group() : interactivity_manager::get_singleton_instance()->group(*GroupName.ToString());
+		std::shared_ptr<interactive_scene> TargetScene = interactivity_manager::get_singleton_instance()->scene(*Scene.ToString());
+		if (Group != nullptr && TargetScene != nullptr)
+		{
+			Group->set_scene(TargetScene);
+		}
+	}
+}
+
+FName FMixerInteractivityModule_InteractiveCpp::GetCurrentScene(FName GroupName)
+{
+	using namespace Microsoft::mixer;
+	FName SceneName = NAME_None;
+	if (GetInteractivityState() == EMixerInteractivityState::Interactive)
+	{
+		std::shared_ptr<interactive_group> Group = GroupName == NAME_None ? interactivity_manager::get_singleton_instance()->group() : interactivity_manager::get_singleton_instance()->group(*GroupName.ToString());
+		if (Group && Group->scene())
+		{
+			SceneName = Group->scene()->scene_id().c_str();
+		}
+	}
+	return SceneName;
+}
+
+void FMixerInteractivityModule_InteractiveCpp::TriggerButtonCooldown(FName Button, FTimespan CooldownTime)
+{
+	using namespace Microsoft::mixer;
+
+	if (GetInteractivityState() == EMixerInteractivityState::Interactive)
+	{
+		std::chrono::milliseconds CooldownTimeInMs = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::duration<double, std::milli>(CooldownTime.GetTotalMilliseconds()));
+		interactivity_manager::get_singleton_instance()->get_singleton_instance()->trigger_cooldown(*Button.ToString(), CooldownTimeInMs);
+	}
+}
+
+bool FMixerInteractivityModule_InteractiveCpp::GetButtonDescription(FName Button, FMixerButtonDescription& OutDesc)
+{
+	using namespace Microsoft::mixer;
+
+	std::shared_ptr<interactive_button_control> ButtonControl = FindButton(Button);
+	if (ButtonControl)
+	{
+		OutDesc.ButtonText = FText::FromString(ButtonControl->button_text().c_str());
+		OutDesc.HelpText = FText::GetEmpty(); //FText::FromString(ButtonControl->help_text().c_str());
+		OutDesc.SparkCost = ButtonControl->cost();
+		return true;
+	}
+	return false;
+}
+
+bool FMixerInteractivityModule_InteractiveCpp::GetButtonState(FName Button, FMixerButtonState& OutState)
+{
+	using namespace Microsoft::mixer;
+
+	std::shared_ptr<interactive_button_control> ButtonControl = FindButton(Button);
+	if (ButtonControl)
+	{
+		OutState.RemainingCooldown = FTimespan::FromMilliseconds(ButtonControl->remaining_cooldown().count());
+		OutState.Progress = ButtonControl->progress();
+		OutState.PressCount = ButtonControl->count_of_button_presses();
+		OutState.DownCount = ButtonControl->count_of_button_downs();
+		OutState.UpCount = ButtonControl->count_of_button_ups();
+		OutState.Enabled = !ButtonControl->disabled();
+		return true;
+	}
+	return false;
+}
+
+bool FMixerInteractivityModule_InteractiveCpp::GetButtonState(FName Button, uint32 ParticipantId, FMixerButtonState& OutState)
+{
+	using namespace Microsoft::mixer;
+
+	std::shared_ptr<interactive_button_control> ButtonControl = FindButton(Button);
+	if (ButtonControl)
+	{
+		OutState.RemainingCooldown = FTimespan::FromMilliseconds(ButtonControl->remaining_cooldown().count());
+		OutState.Progress = ButtonControl->progress();
+		OutState.PressCount = ButtonControl->is_pressed(ParticipantId) ? 1 : 0;
+		OutState.DownCount = ButtonControl->is_down(ParticipantId) ? 1 : 0;
+		OutState.UpCount = ButtonControl->is_up(ParticipantId) ? 1 : 0;
+		OutState.Enabled = !ButtonControl->disabled();
+		return true;
+	}
+	return false;
+}
+
+bool FMixerInteractivityModule_InteractiveCpp::GetStickDescription(FName Stick, FMixerStickDescription& OutDesc)
+{
+	using namespace Microsoft::mixer;
+
+	std::shared_ptr<interactive_joystick_control> StickControl = FindStick(Stick);
+	if (StickControl)
+	{
+		OutDesc.HelpText = FText::GetEmpty(); //FText::FromString(StickControl->help_text().c_str());
+		return true;
+	}
+	return false;
+}
+
+bool FMixerInteractivityModule_InteractiveCpp::GetStickState(FName Stick, FMixerStickState& OutState)
+{
+	using namespace Microsoft::mixer;
+
+	std::shared_ptr<interactive_joystick_control> StickControl = FindStick(Stick);
+	if (StickControl)
+	{
+		OutState.Axes = FVector2D(static_cast<float>(StickControl->x()), static_cast<float>(StickControl->y()));
+		OutState.Enabled = true; //!StickControl->disabled();
+		return true;
+	}
+	return false;
+}
+
+bool FMixerInteractivityModule_InteractiveCpp::GetStickState(FName Stick, uint32 ParticipantId, FMixerStickState& OutState)
+{
+	using namespace Microsoft::mixer;
+
+	std::shared_ptr<interactive_joystick_control> StickControl = FindStick(Stick);
+	if (StickControl)
+	{
+		OutState.Axes = FVector2D(static_cast<float>(StickControl->x(ParticipantId)), static_cast<float>(StickControl->y(ParticipantId)));
+		OutState.Enabled = true; //!StickControl->disabled();
+		return true;
+	}
+	return false;
+}
+
+std::shared_ptr<Microsoft::mixer::interactive_button_control> FMixerInteractivityModule_InteractiveCpp::FindButton(FName Name)
+{
+	using namespace Microsoft::mixer;
+
+	if (GetInteractivityState() == EMixerInteractivityState::Interactive)
+	{
+		FString NameAsString = Name.ToString();
+		for (const std::shared_ptr<interactive_scene> SceneObject : interactivity_manager::get_singleton_instance()->scenes())
+		{
+			if (SceneObject)
+			{
+				std::shared_ptr<Microsoft::mixer::interactive_button_control> ButtonControl = SceneObject->button(*NameAsString);
+				if (ButtonControl)
+				{
+					return ButtonControl;
+				}
+			}
+		}
+	}
+
+	return nullptr;
+}
+
+std::shared_ptr<Microsoft::mixer::interactive_joystick_control> FMixerInteractivityModule_InteractiveCpp::FindStick(FName Name)
+{
+	using namespace Microsoft::mixer;
+
+	if (GetInteractivityState() == EMixerInteractivityState::Interactive)
+	{
+		FString NameAsString = Name.ToString();
+		for (const std::shared_ptr<interactive_scene> SceneObject : interactivity_manager::get_singleton_instance()->scenes())
+		{
+			if (SceneObject)
+			{
+				std::shared_ptr<Microsoft::mixer::interactive_joystick_control> StickControl = SceneObject->joystick(*NameAsString);
+				if (StickControl)
+				{
+					return StickControl;
+				}
+			}
+		}
+	}
+
+	return nullptr;
+}
+
+TSharedPtr<const FMixerRemoteUser> FMixerInteractivityModule_InteractiveCpp::GetParticipant(uint32 ParticipantId)
+{
+	using namespace Microsoft::mixer;
+
+	if (GetInteractivityState() == EMixerInteractivityState::Interactive)
+	{
+		TSharedPtr<FMixerRemoteUserCached>* CachedUser = RemoteParticipantCache.Find(ParticipantId);
+		if (CachedUser)
+		{
+			return *CachedUser;
+		}
+
+		for (std::shared_ptr<interactive_participant> Participant : interactivity_manager::get_singleton_instance()->participants())
+		{
+			check(Participant);
+			if (Participant->mixer_id() == ParticipantId)
+			{
+				return CreateOrUpdateCachedParticipant(Participant);
+			}
+		}
+	}
+
+	return nullptr;
+}
+
+bool FMixerInteractivityModule_InteractiveCpp::CreateGroup(FName GroupName, FName InitialScene)
+{
+	using namespace Microsoft::mixer;
+
+	FString GroupNameAsString = GroupName.ToString();
+	std::shared_ptr<interactive_group> FoundGroup = interactivity_manager::get_singleton_instance()->group(*GroupName.ToString());
+	bool CanCreate = FoundGroup == nullptr;
+	if (CanCreate)
+	{
+		if (InitialScene != NAME_None)
+		{
+			std::shared_ptr<interactive_scene> TargetScene = interactivity_manager::get_singleton_instance()->scene(*InitialScene.ToString());
+			if (TargetScene)
+			{
+				std::make_shared<interactive_group>(*GroupNameAsString, TargetScene);
+			}
+			else
+			{
+				CanCreate = false;
+			}
+		}
+		else
+		{
+			// Constructor adds it to the internal manager.
+			std::make_shared<interactive_group>(*GroupNameAsString);
+		}
+	}
+
+	return CanCreate;
+}
+
+bool FMixerInteractivityModule_InteractiveCpp::GetParticipantsInGroup(FName GroupName, TArray<TSharedPtr<const FMixerRemoteUser>>& OutParticipants)
+{
+	using namespace Microsoft::mixer;
+
+	std::shared_ptr<interactive_group> ExistingGroup = interactivity_manager::get_singleton_instance()->group(*GroupName.ToString());
+	bool FoundGroup = false;
+	if (ExistingGroup)
+	{
+		FoundGroup = true;
+		const std::vector<std::shared_ptr<interactive_participant>> ParticipantsInternal = ExistingGroup->participants();
+		OutParticipants.Empty(ParticipantsInternal.size());
+		for (std::shared_ptr<interactive_participant> Participant : ParticipantsInternal)
+		{
+			OutParticipants.Add(CreateOrUpdateCachedParticipant(Participant));
+		}
+	}
+	else
+	{
+		OutParticipants.Empty();
+	}
+
+	return FoundGroup;
+}
+
+bool FMixerInteractivityModule_InteractiveCpp::MoveParticipantToGroup(FName GroupName, uint32 ParticipantId)
+{
+	using namespace Microsoft::mixer;
+
+	FString GroupNameAsString = GroupName.ToString();
+	std::shared_ptr<interactive_group> ExistingGroup = interactivity_manager::get_singleton_instance()->group(*GroupNameAsString);
+	bool FoundUser = false;
+	if (ExistingGroup)
+	{
+		std::shared_ptr<interactive_participant> Participant;
+		TSharedPtr<FMixerRemoteUserCached>* CachedUser = RemoteParticipantCache.Find(ParticipantId);
+		if (CachedUser)
+		{
+			Participant = (*CachedUser)->GetSourceParticipant();
+		}
+		else
+		{
+			for (std::shared_ptr<interactive_participant> PossibleParticipant : interactivity_manager::get_singleton_instance()->participants())
+			{
+				check(PossibleParticipant);
+				if (PossibleParticipant->mixer_id() == ParticipantId)
+				{
+					Participant = PossibleParticipant;
+					break;
+				}
+			}
+		}
+
+		if (Participant)
+		{
+			FoundUser = true;
+			Participant->set_group(ExistingGroup);
+			CreateOrUpdateCachedParticipant(Participant);
+		}
+	}
+	return FoundUser;
+}
+
+void FMixerInteractivityModule_InteractiveCpp::CaptureSparkTransaction(const FString& TransactionId)
+{
+	Microsoft::mixer::interactivity_manager::get_singleton_instance()->capture_transaction(*TransactionId);
+}
+
+void FMixerInteractivityModule_InteractiveCpp::TickParticipantCacheMaintenance()
+{
+	static const FTimespan IntervalForCacheFreshness = FTimespan::FromSeconds(30.0);
+	FDateTime TimeNow = FDateTime::Now();
+	for (TMap<uint32, TSharedPtr<FMixerRemoteUserCached>>::TIterator It(RemoteParticipantCache); It; ++It)
+	{
+		FDateTime MostRecentInteraction = FMath::Max(It.Value()->ConnectedAt, It.Value()->InputAt);
+		if (!It.Value().IsUnique() || TimeNow - MostRecentInteraction < IntervalForCacheFreshness)
+		{
+			It.Value()->UpdateFromSourceParticipant();
+		}
+		else
+		{
+			It.RemoveCurrent();
+		}
+	}
+}
+
+TSharedPtr<FMixerRemoteUserCached> FMixerInteractivityModule_InteractiveCpp::CreateOrUpdateCachedParticipant(std::shared_ptr<Microsoft::mixer::interactive_participant> Participant)
+{
+	check(Participant);
+	TSharedPtr<FMixerRemoteUserCached>& NewUser = RemoteParticipantCache.Add(Participant->mixer_id());
+	if (!NewUser.IsValid())
+	{
+		NewUser = MakeShareable(new FMixerRemoteUserCached(Participant));
+	}
+	NewUser->UpdateFromSourceParticipant();
+	return NewUser;
+}
+
+FMixerRemoteUserCached::FMixerRemoteUserCached(std::shared_ptr<Microsoft::mixer::interactive_participant> InParticipant)
+	: SourceParticipant(InParticipant)
+{
+	Id = SourceParticipant->mixer_id();
+}
+
+void FMixerRemoteUserCached::UpdateFromSourceParticipant()
+{
+	// Is there really not a std definition for this?
+	typedef std::chrono::duration<uint64, std::ratio_multiply<std::nano, std::ratio<100>>> DateTimeTicks;
+
+	Name = SourceParticipant->username().c_str();
+	Level = SourceParticipant->level();
+	ConnectedAt = FDateTime::FromUnixTimestamp(std::chrono::duration_cast<DateTimeTicks>(SourceParticipant->connected_at()).count());
+	InputAt = FDateTime::FromUnixTimestamp(std::chrono::duration_cast<DateTimeTicks>(SourceParticipant->last_input_at()).count());
+	InputEnabled = !SourceParticipant->input_disabled();
+	std::shared_ptr<Microsoft::mixer::interactive_group> GroupInternal = SourceParticipant->group();
+	Group = GroupInternal ? FName(GroupInternal->group_id().c_str()) : NAME_DefaultMixerParticipantGroup;
+}

--- a/Source/MixerInteractivity/Private/MixerInteractivityModule_InteractiveCpp.h
+++ b/Source/MixerInteractivity/Private/MixerInteractivityModule_InteractiveCpp.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#include "MixerInteractivityModulePrivate.h"
+
+namespace Microsoft
+{
+	namespace mixer
+	{
+		class interactive_button_control;
+		class interactive_joystick_control;
+		class interactive_participant;
+		enum interactivity_state : int;
+	}
+}
+
+struct FMixerRemoteUserCached : public FMixerRemoteUser
+{
+public:
+	FMixerRemoteUserCached(std::shared_ptr<Microsoft::mixer::interactive_participant> InParticipant);
+
+	void UpdateFromSourceParticipant();
+
+	std::shared_ptr<Microsoft::mixer::interactive_participant> GetSourceParticipant() { return SourceParticipant; }
+private:
+	std::shared_ptr<Microsoft::mixer::interactive_participant> SourceParticipant;
+};
+
+
+class FMixerInteractivityModule_InteractiveCpp : public FMixerInteractivityModule
+{
+public:
+	virtual void StartInteractivity();
+	virtual void StopInteractivity();
+	virtual void SetCurrentScene(FName Scene, FName GroupName = NAME_None);
+	virtual FName GetCurrentScene(FName GroupName = NAME_None);
+	virtual void TriggerButtonCooldown(FName Button, FTimespan CooldownTime);
+	virtual bool GetButtonDescription(FName Button, FMixerButtonDescription& OutDesc);
+	virtual bool GetButtonState(FName Button, FMixerButtonState& OutState);
+	virtual bool GetButtonState(FName Button, uint32 ParticipantId, FMixerButtonState& OutState);
+	virtual bool GetStickDescription(FName Stick, FMixerStickDescription& OutDesc);
+	virtual bool GetStickState(FName Stick, FMixerStickState& OutState);
+	virtual bool GetStickState(FName Stick, uint32 ParticipantId, FMixerStickState& OutState);
+	virtual TSharedPtr<const FMixerRemoteUser> GetParticipant(uint32 ParticipantId);
+	virtual bool CreateGroup(FName GroupName, FName InitialScene = NAME_None);
+	virtual bool GetParticipantsInGroup(FName GroupName, TArray<TSharedPtr<const FMixerRemoteUser>>& OutParticipants);
+	virtual bool MoveParticipantToGroup(FName GroupName, uint32 ParticipantId);
+	virtual void CaptureSparkTransaction(const FString& TransactionId);
+
+public:
+	virtual bool Tick(float DeltaTime) override;
+
+protected:
+	virtual bool StartInteractiveConnection();
+
+private:
+	std::shared_ptr<Microsoft::mixer::interactive_button_control> FindButton(FName Name);
+	std::shared_ptr<Microsoft::mixer::interactive_joystick_control> FindStick(FName Name);
+	TSharedPtr<FMixerRemoteUserCached> CreateOrUpdateCachedParticipant(std::shared_ptr<Microsoft::mixer::interactive_participant> Participant);
+
+	void TickParticipantCacheMaintenance();
+
+private:
+	TMap<uint32, TSharedPtr<FMixerRemoteUserCached>> RemoteParticipantCache;
+	Microsoft::mixer::interactivity_state ClientLibraryState;
+};
+

--- a/Source/MixerInteractivity/Private/MixerInteractivityModule_InteractiveCpp.h
+++ b/Source/MixerInteractivity/Private/MixerInteractivityModule_InteractiveCpp.h
@@ -1,4 +1,15 @@
+//*********************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+// THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
+// ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY
+// IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR
+// PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
+//
+//*********************************************************
 #pragma once
+
+#if MIXER_BACKEND_INTERACTIVE_CPP
 
 #include "MixerInteractivityModulePrivate.h"
 
@@ -64,3 +75,4 @@ private:
 	Microsoft::mixer::interactivity_state ClientLibraryState;
 };
 
+#endif // MIXER_BACKEND_INTERACTIVE_CPP

--- a/Source/MixerInteractivity/Private/MixerInteractivityModule_InteractiveCpp.h
+++ b/Source/MixerInteractivity/Private/MixerInteractivityModule_InteractiveCpp.h
@@ -9,9 +9,9 @@
 //*********************************************************
 #pragma once
 
-#if MIXER_BACKEND_INTERACTIVE_CPP
-
 #include "MixerInteractivityModulePrivate.h"
+
+#if MIXER_BACKEND_INTERACTIVE_CPP
 
 namespace Microsoft
 {

--- a/Source/MixerInteractivity/Private/MixerInteractivityModule_InteractiveCpp.h
+++ b/Source/MixerInteractivity/Private/MixerInteractivityModule_InteractiveCpp.h
@@ -72,7 +72,6 @@ private:
 
 private:
 	TMap<uint32, TSharedPtr<FMixerRemoteUserCached>> RemoteParticipantCache;
-	Microsoft::mixer::interactivity_state ClientLibraryState;
 };
 
 #endif // MIXER_BACKEND_INTERACTIVE_CPP

--- a/Source/MixerInteractivity/Private/MixerInteractivityModule_Null.cpp
+++ b/Source/MixerInteractivity/Private/MixerInteractivityModule_Null.cpp
@@ -1,0 +1,18 @@
+//*********************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+// THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
+// ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY
+// IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR
+// PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
+//
+//*********************************************************
+#include "MixerInteractivityModule_Null.h"
+
+#if MIXER_BACKEND_NULL
+IMPLEMENT_MODULE(FMixerInteractivityModule_Null, MixerInteractivity);
+#endif
+
+// Suppress linker warning "warning LNK4221: no public symbols found; archive member will be inaccessible"
+int32 MixerNullLinkerHelper;
+

--- a/Source/MixerInteractivity/Private/MixerInteractivityModule_Null.h
+++ b/Source/MixerInteractivity/Private/MixerInteractivityModule_Null.h
@@ -1,0 +1,40 @@
+//*********************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+// THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
+// ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY
+// IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR
+// PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
+//
+//*********************************************************
+#pragma once
+
+#include "MixerInteractivityModulePrivate.h"
+
+#if MIXER_BACKEND_NULL
+
+class FMixerInteractivityModule_Null : public FMixerInteractivityModule
+{
+public:
+	virtual void StartInteractivity() {}
+	virtual void StopInteractivity() {}
+	virtual void SetCurrentScene(FName Scene, FName GroupName = NAME_None) {}
+	virtual FName GetCurrentScene(FName GroupName = NAME_None) { return NAME_None; }
+	virtual void TriggerButtonCooldown(FName Button, FTimespan CooldownTime) {}
+	virtual bool GetButtonDescription(FName Button, FMixerButtonDescription& OutDesc) { return false; }
+	virtual bool GetButtonState(FName Button, FMixerButtonState& OutState) { return false; }
+	virtual bool GetButtonState(FName Button, uint32 ParticipantId, FMixerButtonState& OutState) { return false; }
+	virtual bool GetStickDescription(FName Stick, FMixerStickDescription& OutDesc) { return false; }
+	virtual bool GetStickState(FName Stick, FMixerStickState& OutState) { return false; }
+	virtual bool GetStickState(FName Stick, uint32 ParticipantId, FMixerStickState& OutState) { return false; }
+	virtual TSharedPtr<const FMixerRemoteUser> GetParticipant(uint32 ParticipantId) { return nullptr; }
+	virtual bool CreateGroup(FName GroupName, FName InitialScene = NAME_None) { return false; }
+	virtual bool GetParticipantsInGroup(FName GroupName, TArray<TSharedPtr<const FMixerRemoteUser>>& OutParticipants) { return false; }
+	virtual bool MoveParticipantToGroup(FName GroupName, uint32 ParticipantId) { return false; }
+	virtual void CaptureSparkTransaction(const FString& TransactionId) {}
+
+protected:
+	virtual bool StartInteractiveConnection() { return false; }
+};
+
+#endif // MIXER_BACKEND_NULL


### PR DESCRIPTION
and provide null implementation of the pieces that depend on it.  Allows games to take a direct dependency on the Mixer Interactivity module and still build for platforms where there is no interactive-cpp available.